### PR TITLE
Fix padding calc in Pile

### DIFF
--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -139,7 +139,7 @@ pub struct PileAux<const MAX_PILE_SIZE: usize, H: HashProtocol> {
 }
 
 fn new_length_and_padding(current_length: usize, blob_size: usize) -> (usize, usize) {
-    let padding = 64 - (blob_size % 64);
+    let padding = (64 - (blob_size % 64)) % 64;
     let new_length = current_length + 64 + blob_size + padding;
     (new_length, padding)
 }


### PR DESCRIPTION
## Summary
- fix padding calculation for blobs in `Pile`

## Testing
- `cargo test --all --quiet` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683c8cb727d88322ac7ad529df5611c6