### PR TITLE
Fix estimate counts

### DIFF
--- a/src/query/hashmapconstraint.rs
+++ b/src/query/hashmapconstraint.rs
@@ -37,7 +37,8 @@ where
 
     fn estimate(&self, variable: VariableId, _binding: &Binding) -> Option<usize> {
         if self.variable.index == variable {
-            Some(self.map.capacity())
+            // the estimated proposal count equals the current number of keys
+            Some(self.map.len())
         } else {
             None
         }

--- a/src/query/hashsetconstraint.rs
+++ b/src/query/hashsetconstraint.rs
@@ -33,7 +33,8 @@ where
 
     fn estimate(&self, variable: VariableId, _binding: &Binding) -> Option<usize> {
         if self.variable.index == variable {
-            Some(self.set.capacity())
+            // use the current set length as the estimate for proposal count
+            Some(self.set.len())
         } else {
             None
         }


### PR DESCRIPTION
## Summary
- use `len()` for query estimates for map and set constraints
- document meaning of estimate

## Testing
- `cargo check` *(fails: could not download crates)*
- `cargo test` *(fails: could not download crates)*
- `cargo fmt -- --check` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c905409348322ae20cf8fda278557