### PR TITLE
Fix Workspace Debug bounds and RepoPushResult

### DIFF
--- a/src/patch.rs
+++ b/src/patch.rs
@@ -14,7 +14,6 @@ mod entry;
 mod leaf;
 
 use arrayvec::ArrayVec;
-use sptr::Strict;
 
 use branch::*;
 pub use entry::Entry;


### PR DESCRIPTION
## Summary
- implement custom Debug for `Workspace` requiring `BlobStore::Reader: Debug`
- implement Debug manually for `RepoPushResult`
- remove unused `sptr::Strict` import

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_683cdf1877d083229a7c9d6e4c4bef11