### PR TITLE
Reduce dataset size in tests

### DIFF
--- a/src/blob/memoryblobstore.rs
+++ b/src/blob/memoryblobstore.rs
@@ -332,7 +332,7 @@ mod tests {
     fn keep() {
         let mut kb = TribleSet::new();
         let mut blobs = MemoryBlobStore::new();
-        for _i in 0..2000 {
+        for _i in 0..200 {
             kb.union(knights2::entity!({
                 description: blobs.put(Bytes::from_source(Name(EN).fake::<String>()).view().unwrap()).unwrap()
             }));

--- a/src/blob/schemas/succinctarchive/universe.rs
+++ b/src/blob/schemas/succinctarchive/universe.rs
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn ids_compressed() {
-        let size = 1000;
+        let size = 100;
 
         let count_data: Vec<_> = (0..size as u128)
             .map(|id| id_into_value(&id.to_be_bytes()))
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn ids_uncompressed() {
-        let size = 1000;
+        let size = 100;
 
         let count_data: Vec<_> = (0..size as u128)
             .map(|id| id_into_value(&id.to_be_bytes()))

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn ns_pattern_large() {
         let mut kb = TribleSet::new();
-        (0..10000).for_each(|_| {
+        (0..100).for_each(|_| {
             let author = ufoid();
             let book = ufoid();
             kb += literature::entity!(&author, {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1462,8 +1462,8 @@ mod tests {
         }
 
         #[test]
-        fn tree_union(left in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 2000),
-                        right in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 2000)) {
+        fn tree_union(left in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 200),
+                        right in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 200)) {
             let mut set = HashSet::new();
 
             let mut left_tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();

--- a/src/query.rs
+++ b/src/query.rs
@@ -633,7 +633,7 @@ mod tests {
     #[test]
     fn pattern() {
         let mut kb = TribleSet::new();
-        (0..1000000).for_each(|_| {
+        (0..1000).for_each(|_| {
             let author = fucid();
             let book = fucid();
             kb += literature::entity!(&author, {
@@ -664,7 +664,7 @@ mod tests {
                     has gone there will be nothing. Only I will remain.".to_blob().get_handle()
         });
 
-        (0..1000).for_each(|_| {
+        (0..100).for_each(|_| {
             let author = fucid();
             let book = fucid();
             kb += literature::entity!(&author, {

--- a/src/trible/tribleset.rs
+++ b/src/trible/tribleset.rs
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn union() {
         let mut kb = TribleSet::new();
-        for _i in 0..2000 {
+        for _i in 0..100 {
             let author = ufoid();
             let book = ufoid();
             kb += literature::entity!(&author, {
@@ -221,12 +221,12 @@ mod tests {
                 author: &author
             });
         }
-        assert_eq!(kb.len(), 8000);
+        assert_eq!(kb.len(), 400);
     }
 
     #[test]
     fn union_parallel() {
-        let kb = (0..1000000)
+        let kb = (0..1000)
             .into_par_iter()
             .flat_map(|_| {
                 let author = ufoid();
@@ -243,14 +243,14 @@ mod tests {
                 ]
             })
             .reduce(|| TribleSet::new(), |a, b| a + b);
-        assert_eq!(kb.len(), 4000000);
+        assert_eq!(kb.len(), 4000);
     }
 
     #[test]
     fn intersection() {
         let mut kb1 = TribleSet::new();
         let mut kb2 = TribleSet::new();
-        for _i in 0..1000 {
+        for _i in 0..100 {
             let author = ufoid();
             let book = ufoid();
             kb1 += literature::entity!(&author, {
@@ -282,7 +282,7 @@ mod tests {
     fn difference() {
         let mut kb1 = TribleSet::new();
         let mut kb2 = TribleSet::new();
-        for _i in 0..1000 {
+        for _i in 0..100 {
             let author = ufoid();
             let book = ufoid();
             kb1 += literature::entity!(&author, {


### PR DESCRIPTION
## Summary
- shrink large loops in tests to shorten runtime
- format modified files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683ce4cc76408322a681471d3a502193