### PR TITLE
Add repository example

### DIFF
--- a/examples/repo.rs
+++ b/examples/repo.rs
@@ -1,0 +1,47 @@
+use ed25519_dalek::SigningKey;
+use tribles::examples::literature;
+use tribles::prelude::*;
+use tribles::repo::{commit::commit, RepoPushResult, Repository};
+
+fn main() {
+    const MAX_PILE_SIZE: usize = 1 << 20;
+    let tmp = tempfile::tempdir().expect("tmp dir");
+    let path = tmp.path().join("repo.pile");
+
+    // Create a local pile to store blobs and branches
+    let mut pile: Pile<MAX_PILE_SIZE> = Pile::open(&path).expect("open pile");
+
+    let key = SigningKey::generate(&mut rand::rngs::OsRng);
+
+    // Create an initial commit that just stores an empty dataset
+    let init_blob = TribleSet::new().to_blob();
+    let init_commit_set = commit(&key, [], Some("init"), Some(init_blob.clone()));
+    pile.put(init_blob).expect("store blob");
+    let init_commit = pile.put(init_commit_set.to_blob()).expect("store commit");
+
+    // Create a repository from the pile and initialize the main branch
+    let mut repo = Repository::new(pile);
+    let branch_id = repo.branch("main", init_commit, key.clone());
+
+    // First workspace adds Alice and pushes
+    let mut ws1 = repo.checkout(branch_id).expect("checkout");
+    let mut change = TribleSet::new();
+    change += literature::entity!(&ufoid(), { firstname: "Alice" });
+    ws1.commit(change, Some("add alice"));
+    repo.push(&mut ws1).expect("push ws1");
+
+    // Second workspace adds Bob and attempts to push, merging on conflict
+    let mut ws2 = repo.checkout(branch_id).expect("checkout");
+    let mut change = TribleSet::new();
+    change += literature::entity!(&ufoid(), { firstname: "Bob" });
+    ws2.commit(change, Some("add bob"));
+
+    loop {
+        match repo.push(&mut ws2).expect("push ws2") {
+            RepoPushResult::Success() => break,
+            RepoPushResult::Conflict(mut other) => {
+                ws2.merge(&mut other).expect("merge");
+            }
+        }
+    }
+}

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -355,6 +355,21 @@ where
     BadBranchMetadata(),
 }
 
+impl<B, C> fmt::Debug for CheckoutError<B, C>
+where
+    B: Error + fmt::Debug,
+    C: Error + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CheckoutError::BranchNotFound(id) => f.debug_tuple("BranchNotFound").field(id).finish(),
+            CheckoutError::BranchStorage(e) => f.debug_tuple("BranchStorage").field(e).finish(),
+            CheckoutError::BlobStorage(e) => f.debug_tuple("BlobStorage").field(e).finish(),
+            CheckoutError::BadBranchMetadata() => f.debug_tuple("BadBranchMetadata").finish(),
+        }
+    }
+}
+
 impl<Storage> Repository<Storage>
 where
     Storage: BlobStore<Blake3> + BranchStore<Blake3>,

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -35,6 +35,7 @@ use memmap2::MmapOptions;
 use reft_light::{Apply, ReadHandle, WriteHandle};
 use std::convert::Infallible;
 use std::error::Error;
+use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::ops::Bound;
 use std::path::Path;
@@ -228,6 +229,15 @@ impl<const MAX_PILE_SIZE: usize, H: HashProtocol> Apply<PileSwap<H>, PileAux<MAX
 
 pub struct Pile<const MAX_PILE_SIZE: usize, H: HashProtocol = Blake3> {
     w_handle: WriteHandle<PileBlobStoreOps<H>, PileSwap<H>, PileAux<MAX_PILE_SIZE, H>>,
+}
+
+impl<const MAX_PILE_SIZE: usize, H> fmt::Debug for Pile<MAX_PILE_SIZE, H>
+where
+    H: HashProtocol,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Pile").finish()
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- add new `examples/repo.rs` using a single key and merging on conflict
- implement `Debug` for `CheckoutError` and `Pile`

## Testing
- `cargo fmt --all`
- `cargo test --quiet readme_example -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_683ce29143a0832295c8ca43d584f673