### PR TITLE
Add integration tests for repository workflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,43 +18,43 @@ pub mod examples;
 // Let's add the readme example as a test
 #[cfg(test)]
 mod readme_example {
-use crate::prelude::*;
-use crate::prelude::valueschemas::*;
-use crate::prelude::blobschemas::*;
-use crate::examples::literature;
+    use crate::examples::literature;
+    use crate::prelude::blobschemas::*;
+    use crate::prelude::valueschemas::*;
+    use crate::prelude::*;
 
-#[test]
-fn readme_example() -> Result<(), Box<dyn std::error::Error>> {
-    let mut blobs = MemoryBlobStore::new();
-    let mut set = TribleSet::new();
+    #[test]
+    fn readme_example() -> Result<(), Box<dyn std::error::Error>> {
+        let mut blobs = MemoryBlobStore::new();
+        let mut set = TribleSet::new();
 
-    let author_id = ufoid();
+        let author_id = ufoid();
 
-    // Note how the entity macro returns TribleSets that can be cheaply merged
-    // into our existing dataset.
-    set += literature::entity!(&author_id, {
-                firstname: "Frank",
-                lastname: "Herbert",
-            });
+        // Note how the entity macro returns TribleSets that can be cheaply merged
+        // into our existing dataset.
+        set += literature::entity!(&author_id, {
+            firstname: "Frank",
+            lastname: "Herbert",
+        });
 
-    set += literature::entity!({
-                title: "Dune",
-                author: &author_id,
-                quote: blobs.put("Deep in the human unconscious is a \
-                pervasive need for a logical universe that makes sense. \
-                But the real universe is always one step beyond logic.").unwrap(),
-                quote: blobs.put("I must not fear. Fear is the \
-                mind-killer. Fear is the little-death that brings total \
-                obliteration. I will face my fear. I will permit it to \
-                pass over me and through me. And when it has gone past I \
-                will turn the inner eye to see its path. Where the fear \
-                has gone there will be nothing. Only I will remain.").unwrap(),
-            });
+        set += literature::entity!({
+            title: "Dune",
+            author: &author_id,
+            quote: blobs.put("Deep in the human unconscious is a \
+            pervasive need for a logical universe that makes sense. \
+            But the real universe is always one step beyond logic.").unwrap(),
+            quote: blobs.put("I must not fear. Fear is the \
+            mind-killer. Fear is the little-death that brings total \
+            obliteration. I will face my fear. I will permit it to \
+            pass over me and through me. And when it has gone past I \
+            will turn the inner eye to see its path. Where the fear \
+            has gone there will be nothing. Only I will remain.").unwrap(),
+        });
 
-    let title = "Dune";
+        let title = "Dune";
 
-    // We can then find all entities matching a certain pattern in our dataset.
-    for (_, f, l, q) in find!(
+        // We can then find all entities matching a certain pattern in our dataset.
+        for (_, f, l, q) in find!(
         (author: (), first: String, last: Value<_>, quote),
         literature::pattern!(&set, [
             { author @
@@ -65,12 +65,13 @@ fn readme_example() -> Result<(), Box<dyn std::error::Error>> {
                 title: (title),
                 author: author,
                 quote: quote
-            }])) {
-        let q: View<str> = blobs.reader().get(q).unwrap();
-        let q = q.as_ref();
+            }]))
+        {
+            let q: View<str> = blobs.reader().get(q).unwrap();
+            let q = q.as_ref();
 
-        println!("'{q}'\n - from {title} by {f} {}.", l.from_value::<&str>())
+            println!("'{q}'\n - from {title} by {f} {}.", l.from_value::<&str>())
+        }
+        Ok(())
     }
-    Ok(())
-}
 }

--- a/tests/branch.rs
+++ b/tests/branch.rs
@@ -1,0 +1,24 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use tribles::prelude::*;
+use tribles::repo::{self, Repository};
+
+mod util;
+use util::InMemoryRepo;
+
+#[test]
+fn repository_branch_creates_branch() {
+    let mut storage = InMemoryRepo::default();
+    let commit_key = SigningKey::generate(&mut OsRng);
+    let commit_set = repo::commit::commit(&commit_key, [], None, None);
+    let commit_handle = storage.put(commit_set).unwrap();
+
+    let branch_key = SigningKey::generate(&mut OsRng);
+    let mut repo = Repository::new(storage);
+    let branch_id = repo.branch("main", commit_handle, branch_key);
+
+    match repo.checkout(branch_id) {
+        Ok(_) => {}
+        Err(_) => panic!("checkout failed"),
+    }
+}

--- a/tests/branch_store.rs
+++ b/tests/branch_store.rs
@@ -1,0 +1,34 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use tribles::prelude::*;
+use tribles::repo::{self, PushResult};
+
+mod util;
+use util::InMemoryRepo;
+
+#[test]
+fn branch_update_success_and_conflict() {
+    let mut store = InMemoryRepo::default();
+    let key = SigningKey::generate(&mut OsRng);
+    let commit1 = repo::commit::commit(&key, [], None, None);
+    let h1 = store.put(commit1).unwrap();
+    let branch_id = *ufoid();
+
+    match store.update(branch_id, None, h1) {
+        Ok(PushResult::Success()) => {}
+        _ => panic!("expected success"),
+    }
+
+    let commit2 = repo::commit::commit(&key, [h1], None, None);
+    let h2 = store.put(commit2).unwrap();
+
+    match store.update(branch_id, None, h2) {
+        Ok(PushResult::Conflict(Some(existing))) => assert_eq!(existing, h1),
+        r => panic!("unexpected result: {:?}", r),
+    }
+
+    match store.update(branch_id, Some(h1), h2) {
+        Ok(PushResult::Success()) => {}
+        _ => panic!("expected success"),
+    }
+}

--- a/tests/push_merge.rs
+++ b/tests/push_merge.rs
@@ -1,0 +1,47 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use tribles::prelude::*;
+use tribles::repo::{self, RepoPushResult, Repository};
+
+mod util;
+use util::InMemoryRepo;
+
+#[test]
+fn push_and_merge_conflict_resolution() {
+    let mut storage = InMemoryRepo::default();
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let base_commit = repo::commit::commit(&signing_key, [], None, None);
+    let base_handle = storage.put(base_commit).unwrap();
+    let branch_key = SigningKey::generate(&mut OsRng);
+    let mut repo = Repository::new(storage);
+    let branch_id = repo.branch("main", base_handle, branch_key);
+
+    let mut ws1 = match repo.checkout(branch_id) {
+        Ok(ws) => ws,
+        Err(_) => panic!("checkout failed"),
+    };
+    let mut ws2 = match repo.checkout(branch_id) {
+        Ok(ws) => ws,
+        Err(_) => panic!("checkout failed"),
+    };
+
+    ws1.commit(TribleSet::new(), Some("first"));
+    ws2.commit(TribleSet::new(), Some("second"));
+
+    match repo.push(&mut ws1).expect("push") {
+        RepoPushResult::Success() => {}
+        _ => panic!("expected success"),
+    }
+
+    let mut conflict_ws = match repo.push(&mut ws2).expect("push") {
+        RepoPushResult::Conflict(ws) => ws,
+        _ => panic!("expected conflict"),
+    };
+
+    conflict_ws.merge(&mut ws2).unwrap();
+
+    match repo.push(&mut conflict_ws).expect("push") {
+        RepoPushResult::Success() => {}
+        _ => panic!("expected success after merge"),
+    }
+}

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+use std::convert::Infallible;
+
+use tribles::blob::{BlobSchema, MemoryBlobStore, ToBlob};
+use tribles::prelude::blobschemas::SimpleArchive;
+use tribles::prelude::*;
+use tribles::repo::{BranchStore, PushResult};
+use tribles::value::schemas::hash::Blake3;
+
+use tribles::value::schemas::hash::Handle;
+use tribles::value::ValueSchema;
+
+#[derive(Debug)]
+pub struct InMemoryRepo {
+    pub blobs: MemoryBlobStore<Blake3>,
+    pub branches: HashMap<Id, Value<Handle<Blake3, SimpleArchive>>>,
+}
+
+impl Default for InMemoryRepo {
+    fn default() -> Self {
+        Self {
+            blobs: MemoryBlobStore::new(),
+            branches: HashMap::new(),
+        }
+    }
+}
+
+impl tribles::repo::BlobStorePut<Blake3> for InMemoryRepo {
+    type PutError = <MemoryBlobStore<Blake3> as tribles::repo::BlobStorePut<Blake3>>::PutError;
+    fn put<S, T>(&mut self, item: T) -> Result<Value<Handle<Blake3, S>>, Self::PutError>
+    where
+        S: BlobSchema + 'static,
+        T: ToBlob<S>,
+        Handle<Blake3, S>: ValueSchema,
+    {
+        self.blobs.put(item)
+    }
+}
+
+impl tribles::repo::BlobStore<Blake3> for InMemoryRepo {
+    type Reader = <MemoryBlobStore<Blake3> as tribles::repo::BlobStore<Blake3>>::Reader;
+    fn reader(&mut self) -> Self::Reader {
+        self.blobs.reader()
+    }
+}
+
+impl BranchStore<Blake3> for InMemoryRepo {
+    type BranchesError = Infallible;
+    type HeadError = Infallible;
+    type UpdateError = Infallible;
+
+    type ListIter<'a> = std::vec::IntoIter<Result<Id, Self::BranchesError>>;
+
+    fn branches<'a>(&'a self) -> Self::ListIter<'a> {
+        self.branches
+            .keys()
+            .cloned()
+            .map(Ok)
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    fn head(
+        &self,
+        id: Id,
+    ) -> Result<Option<Value<Handle<Blake3, SimpleArchive>>>, Self::HeadError> {
+        Ok(self.branches.get(&id).cloned())
+    }
+
+    fn update(
+        &mut self,
+        id: Id,
+        old: Option<Value<Handle<Blake3, SimpleArchive>>>,
+        new: Value<Handle<Blake3, SimpleArchive>>,
+    ) -> Result<PushResult<Blake3>, Self::UpdateError> {
+        let current = self.branches.get(&id);
+        if current != old.as_ref() {
+            return Ok(PushResult::Conflict(current.cloned()));
+        }
+        self.branches.insert(id, new);
+        Ok(PushResult::Success())
+    }
+}

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,0 +1,30 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use tribles::prelude::*;
+use tribles::repo::{self, RepoPushResult, Repository};
+
+mod util;
+use util::InMemoryRepo;
+
+#[test]
+fn workspace_commit_updates_head() {
+    let mut storage = InMemoryRepo::default();
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let init_commit = repo::commit::commit(&signing_key, [], None, None);
+    let init_handle = storage.put(init_commit).unwrap();
+    let branch_key = SigningKey::generate(&mut OsRng);
+    let mut repo = Repository::new(storage);
+    let branch_id = repo.branch("main", init_handle, branch_key);
+
+    let mut ws = match repo.checkout(branch_id) {
+        Ok(ws) => ws,
+        Err(_) => panic!("checkout failed"),
+    };
+
+    ws.commit(TribleSet::new(), Some("change"));
+
+    match repo.push(&mut ws) {
+        Ok(RepoPushResult::Success()) => {}
+        Ok(_) | Err(_) => panic!("push failed"),
+    }
+}


### PR DESCRIPTION
## Summary
- add a small in-memory repo implementation for tests
- test `Repository::branch` and `Workspace::commit`
- verify branch store conflict handling and push/merge resolution
- run `cargo fmt` on lib tests

## Testing
- `cargo fmt -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683cef1e7f78832281ea966e6062ba10