### PR TITLE
Simplify branch creation API

### DIFF
--- a/examples/repo.rs
+++ b/examples/repo.rs
@@ -1,7 +1,6 @@
-use ed25519_dalek::SigningKey;
 use tribles::examples::literature;
 use tribles::prelude::*;
-use tribles::repo::{commit::commit, RepoPushResult, Repository};
+use tribles::repo::{RepoPushResult, Repository};
 
 fn main() {
     const MAX_PILE_SIZE: usize = 1 << 20;
@@ -11,20 +10,12 @@ fn main() {
     // Create a local pile to store blobs and branches
     let mut pile: Pile<MAX_PILE_SIZE> = Pile::open(&path).expect("open pile");
 
-    let key = SigningKey::generate(&mut rand::rngs::OsRng);
-
-    // Create an initial commit that just stores an empty dataset
-    let init_blob = TribleSet::new().to_blob();
-    let init_commit_set = commit(&key, [], Some("init"), Some(init_blob.clone()));
-    pile.put(init_blob).expect("store blob");
-    let init_commit = pile.put(init_commit_set.to_blob()).expect("store commit");
-
     // Create a repository from the pile and initialize the main branch
     let mut repo = Repository::new(pile);
-    let branch_id = repo.branch("main", init_commit, key.clone());
+    let mut ws1 = repo.branch("main").expect("create branch");
+    let branch_id = ws1.branch_id();
 
     // First workspace adds Alice and pushes
-    let mut ws1 = repo.checkout(branch_id).expect("checkout");
     let mut change = TribleSet::new();
     change += literature::entity!(&ufoid(), { firstname: "Alice" });
     ws1.commit(change, Some("add alice"));

--- a/src/repo/branch.rs
+++ b/src/repo/branch.rs
@@ -45,6 +45,27 @@ pub fn branch(
     metadata
 }
 
+pub fn branch_unsigned(branch_id: Id, name: &str, commit_head: Blob<SimpleArchive>) -> TribleSet {
+    let handle = commit_head.get_handle();
+
+    let metadata_entity = rngid();
+
+    let mut metadata: TribleSet = Default::default();
+
+    metadata += repo::entity!(&metadata_entity,
+    {
+        branch: branch_id,
+        head: handle,
+    });
+
+    metadata += metadata::entity!(&metadata_entity,
+    {
+        name: name,
+    });
+
+    metadata
+}
+
 pub enum ValidationError {
     AmbiguousSignature,
     MissingSignature,

--- a/src/repo/memoryrepo.rs
+++ b/src/repo/memoryrepo.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 
-use tribles::blob::{BlobSchema, MemoryBlobStore, ToBlob};
-use tribles::prelude::blobschemas::SimpleArchive;
-use tribles::prelude::*;
-use tribles::repo::{BranchStore, PushResult};
-use tribles::value::schemas::hash::Blake3;
+use crate::blob::{BlobSchema, MemoryBlobStore, ToBlob};
+use crate::prelude::blobschemas::SimpleArchive;
+use crate::prelude::*;
+use crate::repo::{BranchStore, PushResult};
+use crate::value::schemas::hash::Blake3;
 
-use tribles::value::schemas::hash::Handle;
-use tribles::value::ValueSchema;
+use crate::value::schemas::hash::Handle;
+use crate::value::ValueSchema;
 
 #[derive(Debug)]
 pub struct InMemoryRepo {
@@ -25,8 +25,8 @@ impl Default for InMemoryRepo {
     }
 }
 
-impl tribles::repo::BlobStorePut<Blake3> for InMemoryRepo {
-    type PutError = <MemoryBlobStore<Blake3> as tribles::repo::BlobStorePut<Blake3>>::PutError;
+impl crate::repo::BlobStorePut<Blake3> for InMemoryRepo {
+    type PutError = <MemoryBlobStore<Blake3> as crate::repo::BlobStorePut<Blake3>>::PutError;
     fn put<S, T>(&mut self, item: T) -> Result<Value<Handle<Blake3, S>>, Self::PutError>
     where
         S: BlobSchema + 'static,
@@ -37,8 +37,8 @@ impl tribles::repo::BlobStorePut<Blake3> for InMemoryRepo {
     }
 }
 
-impl tribles::repo::BlobStore<Blake3> for InMemoryRepo {
-    type Reader = <MemoryBlobStore<Blake3> as tribles::repo::BlobStore<Blake3>>::Reader;
+impl crate::repo::BlobStore<Blake3> for InMemoryRepo {
+    type Reader = <MemoryBlobStore<Blake3> as crate::repo::BlobStore<Blake3>>::Reader;
     fn reader(&mut self) -> Self::Reader {
         self.blobs.reader()
     }

--- a/tests/branch.rs
+++ b/tests/branch.rs
@@ -1,18 +1,12 @@
-use ed25519_dalek::SigningKey;
-use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{self, memoryrepo::MemoryRepo, Repository};
+use tribles::repo::{memoryrepo::InMemoryRepo, Repository};
 
 #[test]
 fn repository_branch_creates_branch() {
-    let mut storage = MemoryRepo::default();
-    let commit_key = SigningKey::generate(&mut OsRng);
-    let commit_set = repo::commit::commit(&commit_key, [], None, None);
-    let commit_handle = storage.put(commit_set).unwrap();
-
-    let branch_key = SigningKey::generate(&mut OsRng);
+    let mut storage = InMemoryRepo::default();
     let mut repo = Repository::new(storage);
-    let branch_id = repo.branch("main", commit_handle, branch_key);
+    let ws = repo.branch("main").expect("create branch");
+    let branch_id = ws.branch_id();
 
     match repo.checkout(branch_id) {
         Ok(_) => {}

--- a/tests/branch_store.rs
+++ b/tests/branch_store.rs
@@ -1,11 +1,11 @@
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{self, memoryrepo::MemoryRepo, PushResult};
+use tribles::repo::{self, memoryrepo::InMemoryRepo, PushResult};
 
 #[test]
 fn branch_update_success_and_conflict() {
-    let mut store = MemoryRepo::default();
+    let mut store = InMemoryRepo::default();
     let key = SigningKey::generate(&mut OsRng);
     let commit1 = repo::commit::commit(&key, [], None, None);
     let h1 = store.put(commit1).unwrap();

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,22 +1,11 @@
-use ed25519_dalek::SigningKey;
-use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{self, memoryrepo::MemoryRepo, RepoPushResult, Repository};
+use tribles::repo::{memoryrepo::InMemoryRepo, RepoPushResult, Repository};
 
 #[test]
 fn workspace_commit_updates_head() {
-    let mut storage = MemoryRepo::default();
-    let signing_key = SigningKey::generate(&mut OsRng);
-    let init_commit = repo::commit::commit(&signing_key, [], None, None);
-    let init_handle = storage.put(init_commit).unwrap();
-    let branch_key = SigningKey::generate(&mut OsRng);
+    let storage = InMemoryRepo::default();
     let mut repo = Repository::new(storage);
-    let branch_id = repo.branch("main", init_handle, branch_key);
-
-    let mut ws = match repo.checkout(branch_id) {
-        Ok(ws) => ws,
-        Err(_) => panic!("checkout failed"),
-    };
+    let mut ws = repo.branch("main").expect("create branch");
 
     ws.commit(TribleSet::new(), Some("change"));
 


### PR DESCRIPTION
## Summary
- add `branch_unsigned` helper
- return `Workspace` from new `branch` method
- add `branch_from` for branching from existing commits
- expose `Workspace::branch_id`
- update examples and tests

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_683da140b63c8322a633587d717ffe72