### PR TITLE
Add counts to SuccinctArchive

### DIFF
--- a/src/blob/schemas/succinctarchive.rs
+++ b/src/blob/schemas/succinctarchive.rs
@@ -26,6 +26,10 @@ use sucds::int_vectors::CompactVector;
 pub struct SuccinctArchive<U, B> {
     pub domain: U,
 
+    pub entity_count: usize,
+    pub attribute_count: usize,
+    pub value_count: usize,
+
     pub e_a: EliasFano,
     pub a_a: EliasFano,
     pub v_a: EliasFano,
@@ -73,6 +77,10 @@ where
         let triple_count = set.eav.len() as usize;
         assert!(triple_count > 0);
 
+        let entity_count = set.eav.segmented_len(&[0; 0]) as usize;
+        let attribute_count = set.ave.segmented_len(&[0; 0]) as usize;
+        let value_count = set.vea.segmented_len(&[0; 0]) as usize;
+
         let e_iter = set
             .eav
             .iter_prefix_count::<16>()
@@ -107,7 +115,7 @@ where
         let mut sum = 0;
         let mut last = 0;
         for (a, count) in set
-            .aev
+            .ave
             .iter_prefix_count::<16>()
             .map(|(a, count)| (id_into_value(&a), count as usize))
             .map(|(a, count)| (domain.search(&a).expect("a in domain"), count))
@@ -211,6 +219,9 @@ where
 
         SuccinctArchive {
             domain,
+            entity_count,
+            attribute_count,
+            value_count,
             e_a,
             a_a,
             v_a,

--- a/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
+++ b/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
@@ -101,9 +101,9 @@ where
 
         //TODO add disting color counting ds to archive and estimate better
         Some(match (e_bound, a_bound, v_bound, e_var, a_var, v_var) {
-            (None, None, None, true, false, false) => self.archive.e_a.len(),
-            (None, None, None, false, true, false) => self.archive.a_a.len(),
-            (None, None, None, false, false, true) => self.archive.v_a.len(),
+            (None, None, None, true, false, false) => self.archive.entity_count,
+            (None, None, None, false, true, false) => self.archive.attribute_count,
+            (None, None, None, false, false, true) => self.archive.value_count,
             (Some(e), None, None, false, true, false) => {
                 base_range(&self.archive.domain, &self.archive.e_a, &e).len()
             }


### PR DESCRIPTION
## Summary
- track entity, attribute and value counts in `SuccinctArchive`
- compute these counts when building an archive
- use the counts when estimating unbound query sizes
- avoid materializing prefix vectors when building the archive

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68405dcffc088322bfd871641ba25491