### PR TITLE
Add distinct tracking bitvectors to SuccinctArchive

### DIFF
--- a/src/blob/schemas/succinctarchive.rs
+++ b/src/blob/schemas/succinctarchive.rs
@@ -30,6 +30,13 @@ pub struct SuccinctArchive<U, B> {
     pub a_a: EliasFano,
     pub v_a: EliasFano,
 
+    pub changed_e_a: B,
+    pub changed_e_v: B,
+    pub changed_a_e: B,
+    pub changed_a_v: B,
+    pub changed_v_e: B,
+    pub changed_v_a: B,
+
     pub eav_c: WaveletMatrix<B>,
     pub vea_c: WaveletMatrix<B>,
     pub ave_c: WaveletMatrix<B>,
@@ -61,6 +68,20 @@ where
 
             Trible::force(&e, &a, &v)
         })
+    }
+
+    pub fn distinct_in(&self, bv: &B, range: &std::ops::Range<usize>) -> usize {
+        bv.rank1(range.end).unwrap() - bv.rank1(range.start).unwrap()
+    }
+
+    pub fn enumerate_in<'a>(
+        &'a self,
+        bv: &'a B,
+        range: &std::ops::Range<usize>,
+    ) -> impl Iterator<Item = usize> + 'a {
+        let start = bv.rank1(range.start).unwrap();
+        let end = bv.rank1(range.end).unwrap();
+        (start..end).map(move |r| bv.select1(r).unwrap())
     }
 }
 
@@ -209,11 +230,78 @@ where
             .unwrap();
         let aev_c = WaveletMatrix::new(aev_c).unwrap();
 
+        // Build bit vectors marking the first occurrence of each pair
+        let changed_e_a = B::build_from_bits(
+            set.eav.iter_prefix_count::<32>().flat_map(|(_, c)| {
+                iter::once(true).chain(iter::repeat(false).take(c as usize - 1))
+            }),
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+
+        let changed_e_v = B::build_from_bits(
+            set.eva.iter_prefix_count::<48>().flat_map(|(_, c)| {
+                iter::once(true).chain(iter::repeat(false).take(c as usize - 1))
+            }),
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+
+        let changed_a_e = B::build_from_bits(
+            set.aev.iter_prefix_count::<32>().flat_map(|(_, c)| {
+                iter::once(true).chain(iter::repeat(false).take(c as usize - 1))
+            }),
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+
+        let changed_a_v = B::build_from_bits(
+            set.ave.iter_prefix_count::<48>().flat_map(|(_, c)| {
+                iter::once(true).chain(iter::repeat(false).take(c as usize - 1))
+            }),
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+
+        let changed_v_e = B::build_from_bits(
+            set.vea.iter_prefix_count::<48>().flat_map(|(_, c)| {
+                iter::once(true).chain(iter::repeat(false).take(c as usize - 1))
+            }),
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+
+        let changed_v_a = B::build_from_bits(
+            set.vae.iter_prefix_count::<48>().flat_map(|(_, c)| {
+                iter::once(true).chain(iter::repeat(false).take(c as usize - 1))
+            }),
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+
         SuccinctArchive {
             domain,
             e_a,
             a_a,
             v_a,
+            changed_e_a,
+            changed_e_v,
+            changed_a_e,
+            changed_a_v,
+            changed_v_e,
+            changed_v_a,
             eav_c,
             vea_c,
             ave_c,

--- a/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
+++ b/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
@@ -105,22 +105,28 @@ where
             (None, None, None, false, true, false) => self.archive.a_a.len(),
             (None, None, None, false, false, true) => self.archive.v_a.len(),
             (Some(e), None, None, false, true, false) => {
-                base_range(&self.archive.domain, &self.archive.e_a, &e).len()
+                let r = base_range(&self.archive.domain, &self.archive.e_a, &e);
+                self.archive.distinct_in(&self.archive.changed_e_a, &r)
             }
             (Some(e), None, None, false, false, true) => {
-                base_range(&self.archive.domain, &self.archive.e_a, &e).len()
+                let r = base_range(&self.archive.domain, &self.archive.e_a, &e);
+                self.archive.distinct_in(&self.archive.changed_e_v, &r)
             }
             (None, Some(a), None, true, false, false) => {
-                base_range(&self.archive.domain, &self.archive.a_a, &a).len()
+                let r = base_range(&self.archive.domain, &self.archive.a_a, &a);
+                self.archive.distinct_in(&self.archive.changed_a_e, &r)
             }
             (None, Some(a), None, false, false, true) => {
-                base_range(&self.archive.domain, &self.archive.a_a, &a).len()
+                let r = base_range(&self.archive.domain, &self.archive.a_a, &a);
+                self.archive.distinct_in(&self.archive.changed_a_v, &r)
             }
             (None, None, Some(v), true, false, false) => {
-                base_range(&self.archive.domain, &self.archive.v_a, &v).len()
+                let r = base_range(&self.archive.domain, &self.archive.v_a, &v);
+                self.archive.distinct_in(&self.archive.changed_v_e, &r)
             }
             (None, None, Some(v), false, true, false) => {
-                base_range(&self.archive.domain, &self.archive.v_a, &v).len()
+                let r = base_range(&self.archive.domain, &self.archive.v_a, &v);
+                self.archive.distinct_in(&self.archive.changed_v_a, &r)
             }
             (None, Some(a), Some(v), true, false, false) => {
                 let r = base_range(&self.archive.domain, &self.archive.a_a, &a);


### PR DESCRIPTION
## Summary
- track where ordered triples change their second component with six new bitvectors
- expose helpers to count distinct pairs using rank/select
- compute single-bound estimates from change bitvectors
- **fix prefix length bug** when constructing change-tracking bitvectors

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68405dd197dc8322be0d130989583e5e