### PR TITLE
Add simple Kani harness

### DIFF
--- a/kani/value_harness.rs
+++ b/kani/value_harness.rs
@@ -1,0 +1,12 @@
+#![cfg(kani)]
+
+use tribles::value::{schemas::ShortString, Value};
+use tribles::value::{TryFromValue, ValueSchema};
+
+#[kani::proof]
+fn short_string_roundtrip() {
+    let value: Value<ShortString> = ShortString::value_from("hello");
+    let result: Result<&str, _> = value.try_from_value();
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "hello");
+}


### PR DESCRIPTION
## Summary
- add `kani/value_harness.rs` for verifying `ShortString` round‐trip

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684193f2fc48832289f4d06b1e67b0d0