### PR TITLE
Add preflight script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ The project balances a few key goals:
 
 * Run `cargo fmt` on any Rust files you modify.
 * Run `cargo test` and ensure it passes before committing. If tests fail or cannot run, note that in your PR.
+* Before committing, execute `./scripts/preflight.sh` from the repository root. This script runs formatting checks, tests, and Kani verification. Ensure `rustfmt` and the Kani verifier are installed separately. If Kani fails for reasons unrelated to your change, mention it in the PR.
 * Avoid committing files in `target/` or other build artifacts listed in `.gitignore`.
 * Use clear commit messages describing the change.
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Move to repository root
+cd "$(dirname "$0")/.."
+
+# Run formatting check, tests, and Kani verification
+# Assumes rustfmt and the Kani verifier are already installed.
+cargo fmt -- --check
+cargo test
+cargo kani --workspace


### PR DESCRIPTION
## Summary
- update preflight script to only run checks
- note preflight requirements in AGENTS guide

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails: hifitime crate compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68419405bcb483229fbbd3592056ac71