### PR TITLE
Replace panics with unreachable in succinct constraint

### DIFF
--- a/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
+++ b/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::ops::Not;
 use std::ops::Range;
 
@@ -161,7 +160,7 @@ where
                 );
                 r.len()
             }
-            _ => panic!(),
+            _ => unreachable!(),
         })
     }
 
@@ -332,7 +331,7 @@ where
                     .map(|v| self.archive.domain.access(v)),
                 )
             }
-            _ => panic!(),
+            _ => unreachable!(),
         }
     }
 
@@ -519,7 +518,7 @@ where
                     .not()
                 });
             }
-            _ => panic!("invalid trible constraint state"),
+            _ => unreachable!("invalid trible constraint state"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove leftover panic import
- replace three `panic!` fallback branches with `unreachable!`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68421fef00b08322a84c3bc603e9e5cb