### PR TITLE
Remove unused panic import

### DIFF
--- a/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
+++ b/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::ops::Not;
 use std::ops::Range;
 


### PR DESCRIPTION
## Summary
- remove `use core::panic;` from `succinctarchiveconstraint.rs`

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails: could not compile `hifitime`)*

------
https://chatgpt.com/codex/tasks/task_e_68421fd73d048322802ff63761f7955b