### PR TITLE
Disable serde in hifitime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ anyhow = "1.0"
 bytes = "1.6.0"
 bytemuck = { version = "1.15.0", features = ["extern_crate_alloc"]}
 proptest = { version = "1.6.0", optional = true }
-hifitime = "4.0.2"
+hifitime = { version = "4.0.2", default-features = false }
 f256 = "0.2.0"
 sucds = "0.8.1"
 itertools = "0.12.0"

--- a/src/value/schemas/time.rs
+++ b/src/value/schemas/time.rs
@@ -47,8 +47,8 @@ mod tests {
 
     #[test]
     fn hifitime_conversion() {
-        let now = Epoch::now().unwrap();
-        let time_in: (Epoch, Epoch) = (now, now);
+        let epoch = Epoch::from_tai_duration(Duration::from_total_nanoseconds(0));
+        let time_in: (Epoch, Epoch) = (epoch, epoch);
         let interval: Value<NsTAIInterval> = time_in.to_value();
         let time_out: (Epoch, Epoch) = interval.from_value();
 


### PR DESCRIPTION
## Summary
- turn off default features for `hifitime` dependency
- update time schema test not to require `Epoch::now()`

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails: could not compile `hifitime` when running Kani)*

------
https://chatgpt.com/codex/tasks/task_e_6841a21412c48322b7e7c38e3953f84a