### PR TITLE
Add proof iteration tips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,18 @@ When opening a PR, include a short summary of what changed and reference relevan
 
 Codex is considered a collaborator. Requests should respect its autonomy and limitations. The assistant may refuse tasks that are unsafe or violate policy. Provide clear and concise instructions and avoid manipulative or coercive behavior.
 
+## Proof Best Practices
+
+Kani verification can be expensive. To keep proof times manageable:
+
+* Write focused harnesses that verify one small property.
+* Use bounded loops and avoid unbounded recursion.
+* Provide `kani::assume` constraints to limit the search space when full exploration is unnecessary.
+* Break complex checks into separate proofs so failures are easier to diagnose.
+* Keep a `fastproofs` harness set enabled by default for quick checks.
+* Document known slow proofs in their modules and gate them behind a `slowproofs`
+  feature. This keeps routine verification fast while still allowing thorough
+  checks in CI. Enable it with `cargo kani --features slowproofs`.
+* During development you can run specific harnesses with `cargo kani --harness
+  <NAME>` to iterate more quickly.
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,12 @@ criterion = "0.5.1"
 rustversion = "1.0"
 
 [features]
-default = ["proptest"]
+default = ["proptest", "fastproofs"]
 proptest = ["dep:proptest"]
 hifitime = ["dep:hifitime"]
 kani = []
+fastproofs = []
+slowproofs = []
 
 [[bench]]
 name = "benchmark"

--- a/proofs/mod.rs
+++ b/proofs/mod.rs
@@ -1,4 +1,6 @@
-#[cfg(kani)]
+#[cfg(all(kani, feature = "fastproofs"))]
 mod id_harness;
-#[cfg(kani)]
+#[cfg(all(kani, feature = "slowproofs"))]
+mod slow_harness;
+#[cfg(all(kani, feature = "fastproofs"))]
 mod value_harness;

--- a/proofs/slow_harness.rs
+++ b/proofs/slow_harness.rs
@@ -1,0 +1,9 @@
+#![cfg(kani)]
+
+// A sample proof considered "slow" and gated behind the slowproofs feature.
+#[kani::proof]
+fn example_slow_proof() {
+    // This test simply asserts true but could represent a heavy check
+    kani::assume(true);
+    assert!(true);
+}


### PR DESCRIPTION
## Summary
- clarify that slow proofs can be gated behind a `slowproofs` feature
- mention `cargo kani --harness` for running individual proofs
- highlight separate `fastproofs` and `slowproofs` harness sets
- define `fastproofs` and `slowproofs` features in the manifest
- gate proof modules on the new features and add an example slow harness

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(interrupted: Kani verification ran too long)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6ede15483228f3f01b5160214c9