### PR TITLE
Configure Kani unwinding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,9 @@ debug = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)', 'cfg(kani)'] }
+
+[package.metadata.kani.flags]
+default-unwind = "1"
+
+[workspace.metadata.kani.flags]
+default-unwind = "1"

--- a/proofs/value_harness.rs
+++ b/proofs/value_harness.rs
@@ -4,6 +4,7 @@ use crate::value::{schemas::shortstring::ShortString, Value};
 use crate::value::{TryFromValue, ValueSchema};
 
 #[kani::proof]
+#[kani::unwind(32)]
 fn short_string_roundtrip() {
     let value: Value<ShortString> = ShortString::value_from("hello");
     let result: Result<&str, _> = value.try_from_value();


### PR DESCRIPTION
## Summary
- bound utf8 loop unwinding for `ShortString` harness
- default the project to one unwind iteration for Kani

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(interrupted after initial tests)*

------
https://chatgpt.com/codex/tasks/task_e_68462c8e7a208322b4172d712fda41eb