### PR TITLE
Simplify pile open recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The best way to get started is to read the module documentation of the `tribles`
 8. [Remotes](https://docs.rs/tribles/latest/tribles/remote/index.html)
 9. [Predefined Value Schemas](https://docs.rs/tribles/latest/tribles/value/schemas/index.html)
 10. [Predefined Blob Schemas](https://docs.rs/tribles/latest/tribles/blob/schemas/index.html)
+11. [Pile format and recovery](docs/pile.md)
 ## License
 
 Licensed under either of

--- a/docs/pile.md
+++ b/docs/pile.md
@@ -1,0 +1,21 @@
+# Pile Format and Recovery
+
+A `Pile` stores blobs and branches sequentially in a single append-only file. Each
+record begins with a 16 byte magic marker that identifies whether the block is a
+blob or a branch. Blob headers additionally contain a timestamp, the byte length
+of the payload and the hash of the blob. Branch headers contain the branch id and
+the referenced blob hash.
+
+When opening a file, `Pile::try_open` validates that every block header uses one
+of the known markers and that the entire block fits into the file. It does **not**
+verify any hashes. If a record is truncated or has an unknown marker, the function
+returns `OpenError::CorruptPile { valid_length }` where `valid_length` marks the
+number of bytes that belong to well formed blocks.
+
+`Pile::open` provides a convenience wrapper that attempts the same parsing but
+truncates the file to `valid_length` whenever such a corruption error is encountered.
+This recovers from interrupted writes by discarding incomplete bytes so that the
+file can still be used.
+
+Hash verification happens lazily when individual blobs are loaded, keeping the
+initial opening cost low.


### PR DESCRIPTION
## Summary
- clarify how partial block recovery works in docs
- document `try_open` and truncate-based recovery in `Pile::open`
- add `CorruptPile` error with a valid length so open doesn't rescan
- add test for corrupt pile error
- remove obsolete `OpenError` variants
- fix `Pile` recovery code and add tests
- remove unnecessary mut in `try_open`
- remove redundant write flag in `try_open`
- parse blob data with `take_prefix` results instead of length checks
- adjust corrupted pile tests to use longer blobs

## Testing
- `cargo fmt --all -- --check`
- `cargo test --quiet`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_684840e4056c832290581324d13e5f96