### PR TITLE
Simplify key management

### DIFF
--- a/examples/repo.rs
+++ b/examples/repo.rs
@@ -1,3 +1,5 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
 use tribles::examples::literature;
 use tribles::prelude::*;
 use tribles::repo::{RepoPushResult, Repository};
@@ -11,7 +13,7 @@ fn main() {
     let pile: Pile<MAX_PILE_SIZE> = Pile::open(&path).expect("open pile");
 
     // Create a repository from the pile and initialize the main branch
-    let mut repo = Repository::new(pile);
+    let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
     let mut ws1 = repo.branch("main").expect("create branch");
     let branch_id = ws1.branch_id();
 

--- a/proofs/mod.rs
+++ b/proofs/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(kani)]
+mod query_macro_harness;
+#[cfg(kani)]
 mod value_harness;
 #[cfg(kani)]
 mod variableset_harness;
-#[cfg(kani)]
-mod query_macro_harness;

--- a/proofs/query_macro_harness.rs
+++ b/proofs/query_macro_harness.rs
@@ -1,7 +1,7 @@
 #![cfg(kani)]
 
-use crate::prelude::*;
 use crate::examples::literature;
+use crate::prelude::*;
 
 #[kani::proof]
 #[kani::unwind(5)]
@@ -34,9 +34,7 @@ fn query_macro_harness() {
     .collect();
 
     assert_eq!(
-        vec![
-            (book.to_value(), "Hamlet".to_value(), "William".to_value()),
-        ],
+        vec![(book.to_value(), "Hamlet".to_value(), "William".to_value()),],
         result
     );
 }

--- a/tests/branch.rs
+++ b/tests/branch.rs
@@ -1,9 +1,11 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
 use tribles::repo::{memoryrepo::MemoryRepo, Repository};
 
 #[test]
 fn repository_branch_creates_branch() {
     let storage = MemoryRepo::default();
-    let mut repo = Repository::new(storage);
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
     let ws = repo.branch("main").expect("create branch");
     let branch_id = ws.branch_id();
 

--- a/tests/push_merge.rs
+++ b/tests/push_merge.rs
@@ -1,10 +1,12 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
 use tribles::prelude::*;
 use tribles::repo::{memoryrepo::MemoryRepo, RepoPushResult, Repository};
 
 #[test]
 fn push_and_merge_conflict_resolution() {
     let storage = MemoryRepo::default();
-    let mut repo = Repository::new(storage);
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
     let mut ws1 = repo.branch("main").expect("create branch");
     let branch_id = ws1.branch_id();
     let mut ws2 = repo.checkout(branch_id).expect("checkout");

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,10 +1,12 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
 use tribles::prelude::*;
 use tribles::repo::{memoryrepo::MemoryRepo, RepoPushResult, Repository};
 
 #[test]
 fn workspace_commit_updates_head() {
     let storage = MemoryRepo::default();
-    let mut repo = Repository::new(storage);
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
     let mut ws = repo.branch("main").expect("create branch");
 
     ws.commit(TribleSet::new(), Some("change"));


### PR DESCRIPTION
## Summary
- remove the repository key store and related API
- keep an optional signing key on `Repository` for branch creation and checkout
- store a `SigningKey` directly in each workspace
- update examples and tests to set a default signing key
- rename key parameters to `signing_key` and remove temporary variables

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(Kani failed for `proofs::query_macro_harness::query_macro_harness`)*

------
https://chatgpt.com/codex/tasks/task_e_68484162c2288322bc1bbb345f8b90b7