### PR TITLE
Improve Kani string helpers

### DIFF
--- a/proofs/mod.rs
+++ b/proofs/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(kani)]
+mod query_macro_harness;
+#[cfg(kani)]
 mod value_harness;
 #[cfg(kani)]
 mod variableset_harness;
-#[cfg(kani)]
-mod query_macro_harness;

--- a/proofs/query_macro_harness.rs
+++ b/proofs/query_macro_harness.rs
@@ -1,22 +1,27 @@
 #![cfg(kani)]
 
-use crate::prelude::*;
 use crate::examples::literature;
+use crate::prelude::*;
+use kani::BoundedArbitrary;
 
 #[kani::proof]
 #[kani::unwind(5)]
 fn query_macro_harness() {
     // Build a small knowledge base with one author and one book.
-    let author = ufoid();
-    let book = ufoid();
+    let author = ExclusiveId::force(Id::new([1u8; 16]).unwrap());
+    let book = ExclusiveId::force(Id::new([2u8; 16]).unwrap());
+
+    let firstname_str = String::bounded_any::<32>();
+    let lastname_str = String::bounded_any::<32>();
+    let title_str = String::bounded_any::<32>();
 
     let mut set = TribleSet::new();
     set += literature::entity!(&author, {
-        firstname: "William",
-        lastname: "Shakespeare",
+        firstname: &firstname_str,
+        lastname: &lastname_str,
     });
     set += literature::entity!(&book, {
-        title: "Hamlet",
+        title: &title_str,
         author: &author,
     });
 
@@ -25,7 +30,7 @@ fn query_macro_harness() {
         (book, title, firstname),
         literature::pattern!(&set, [
             { firstname: firstname,
-              lastname: ("Shakespeare") },
+              lastname: (&lastname_str) },
             { book @
                 title: title,
                 author: (author) }
@@ -34,9 +39,11 @@ fn query_macro_harness() {
     .collect();
 
     assert_eq!(
-        vec![
-            (book.to_value(), "Hamlet".to_value(), "William".to_value()),
-        ],
+        vec![(
+            book.to_value(),
+            title_str.to_value(),
+            firstname_str.to_value()
+        )],
         result
     );
 }

--- a/proofs/value_harness.rs
+++ b/proofs/value_harness.rs
@@ -2,12 +2,14 @@
 
 use crate::value::{schemas::shortstring::ShortString, Value};
 use crate::value::{TryFromValue, ValueSchema};
+use kani::BoundedArbitrary;
 
 #[kani::proof]
 #[kani::unwind(32)]
 fn short_string_roundtrip() {
-    let value: Value<ShortString> = ShortString::value_from("hello");
+    let s = String::bounded_any::<32>();
+    let value: Value<ShortString> = ShortString::value_from(&s);
     let result: Result<&str, _> = value.try_from_value();
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), "hello");
+    assert_eq!(result.unwrap(), s.as_str());
 }


### PR DESCRIPTION
## Summary
- use `String::bounded_any` for nondeterministic strings
- call the helper directly from proofs
- drop the shim helper module

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(Kani verification failed due to unsupported operations)*

------
https://chatgpt.com/codex/tasks/task_e_6859e333fa4483228d7f6e59da46f3d3