### PR TITLE
Rename query macro harness

### DIFF
--- a/proofs/mod.rs
+++ b/proofs/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(kani)]
-mod query_macro_harness;
+mod query_harness;
 #[cfg(kani)]
 mod value_harness;
 #[cfg(kani)]

--- a/proofs/query_harness.rs
+++ b/proofs/query_harness.rs
@@ -6,10 +6,15 @@ use kani::BoundedArbitrary;
 
 #[kani::proof]
 #[kani::unwind(5)]
-fn query_macro_harness() {
+fn query_harness() {
     // Build a small knowledge base with one author and one book.
-    let author = ExclusiveId::force(Id::new([1u8; 16]).unwrap());
-    let book = ExclusiveId::force(Id::new([2u8; 16]).unwrap());
+    let author_raw: [u8; 16] = kani::any();
+    let book_raw: [u8; 16] = kani::any();
+    kani::assume(author_raw != [0u8; 16]);
+    kani::assume(book_raw != [0u8; 16]);
+    kani::assume(book_raw != author_raw);
+    let author = ExclusiveId::force(Id::new(author_raw).unwrap());
+    let book = ExclusiveId::force(Id::new(book_raw).unwrap());
 
     let firstname_str = String::bounded_any::<32>();
     let lastname_str = String::bounded_any::<32>();


### PR DESCRIPTION
## Summary
- rename `query_macro_harness` to `query_harness`
- make the author and book IDs symbolic in `query_harness`

## Testing
- `cargo test`
- `cargo fmt -- --check`
- `./scripts/preflight.sh` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686194d2fdfc8322b0f3d91ee59266fd