### PR TITLE
Improve Query debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Improved `Debug` output for `Query` to show search state and bindings.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/src/query.rs
+++ b/src/query.rs
@@ -521,7 +521,13 @@ impl<'a, C: Constraint<'a>, P: Fn(&Binding) -> R, R> Iterator for Query<C, P, R>
 
 impl<'a, C: Constraint<'a>, P: Fn(&Binding) -> R, R> fmt::Debug for Query<C, P, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Query") //TODO
+        f.debug_struct("Query")
+            .field("constraint", &std::any::type_name::<C>())
+            .field("mode", &self.mode)
+            .field("binding", &self.binding)
+            .field("stack", &self.stack)
+            .field("unbound", &self.unbound)
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Summary
- implement detailed `Debug` for `Query`
- document the change in the changelog

## Testing
- `cargo fmt`
- `./scripts/preflight.sh` *(failed: Kani verification produced endless output)*

------
https://chatgpt.com/codex/tasks/task_e_686669963b5883229c6e9bc5eb46d77e