### PR TITLE
Remove obsolete TODO in SuccinctArchive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `SuccinctArchive` now counts distinct component pairs using bitsets,
+  improving query estimation accuracy.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
+++ b/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
@@ -98,7 +98,6 @@ where
         let a_bound = binding.get(self.variable_a);
         let v_bound = binding.get(self.variable_v);
 
-        //TODO add disting color counting ds to archive and estimate better
         Some(match (e_bound, a_bound, v_bound, e_var, a_var, v_var) {
             (None, None, None, true, false, false) => self.archive.entity_count,
             (None, None, None, false, true, false) => self.archive.attribute_count,


### PR DESCRIPTION
## Summary
- document bitset-based distinct counting in `SuccinctArchive`
- removed old TODO about adding a distinct-counting data structure

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(Kani verification emitted abort messages)*

------
https://chatgpt.com/codex/tasks/task_e_68667831696c8322997d62e16a87a5f6