### PR TITLE
Refine bucket slot logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.
+- Clarified need for duplicate `bucket_get_slot` check in `table_get_slot`.
 
 ## [0.5.2] - 2025-06-30
 ### Added


### PR DESCRIPTION
## Summary
- clarify the duplicate `bucket_get_slot` check
- move RNG updates into `bucket_shove_random_slot`
- record changes in `CHANGELOG`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68667b0eb750832282f1553f63041233