### PR TITLE
Update proof guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,13 @@ Kani verification can be expensive. To keep proof times manageable:
 
 * Write focused harnesses that verify one small property.
 * Use bounded loops and avoid unbounded recursion.
+* When generating nondeterministic data in proofs, use `kani::any()` for
+  primitive types and `Vec::bounded_any(...)`/`String::bounded_any(...)` for
+  collections. This lets Kani explore the intended state space while bounding
+  otherwise unbounded structures.
+* Avoid using fixed constants in Kani proofs. Prefer nondeterministic values
+  generated with `kani::any()` or the bounded constructors so the verifier can
+  fully explore possible states.
 * Provide `kani::assume` constraints to limit the search space when full exploration is unnecessary.
 * Break complex checks into separate proofs so failures are easier to diagnose.
 * All Kani proofs are considered long running and are executed as part of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   improving query estimation accuracy.
 - Improved `Debug` output for `Query` to show search state and bindings.
 - Replaced branch allocation code with `Layout::from_size_align_unchecked`.
+- Documented Kani proof guidelines to avoid constants and prefer
+  `kani::any()` or bounded constructors for nondeterministic inputs.
 
 ## [0.5.2] - 2025-06-30
 ### Added


### PR DESCRIPTION
## Summary
- expand Kani proof best practices on nondeterministic inputs
- note to avoid constants in proofs

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails to compile `tribles`)*

------
https://chatgpt.com/codex/tasks/task_e_6867d175c8548322ba6357270e276bae