### PR TITLE
Fix constant check in query test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   improving query estimation accuracy.
 - Improved `Debug` output for `Query` to show search state and bindings.
 - Replaced branch allocation code with `Layout::from_size_align_unchecked`.
+- Simplified constant comparison in query tests.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/src/query.rs
+++ b/src/query.rs
@@ -629,7 +629,7 @@ mod tests {
         assert_eq!(cross.len(), 6);
 
         let one: Vec<_> = find!((a: Value<ShortString>),
-            and!(books.has(a), a.is("LOTR".try_to_value().unwrap())) //TODO
+            and!(books.has(a), a.is(ShortString::value_from("LOTR")))
         )
         .collect();
 


### PR DESCRIPTION
## Summary
- simplify constant comparison in query::tests
- note change in changelog

## Testing
- `cargo test -q`
- `./scripts/preflight.sh` *(fails: 4 compilation errors in Kani)*

------
https://chatgpt.com/codex/tasks/task_e_6867d31b4b68832288dec5758eb8c509