### PR TITLE
Simplify blob traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   improving query estimation accuracy.
 - Improved `Debug` output for `Query` to show search state and bindings.
 - Replaced branch allocation code with `Layout::from_size_align_unchecked`.
+- Removed unused `FromBlob` and `TryToBlob` traits and updated documentation.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/src/blob/schemas.rs
+++ b/src/blob/schemas.rs
@@ -10,7 +10,7 @@ use crate::blob::BlobSchema;
 use crate::id::Id;
 use crate::id_hex;
 
-use super::{Blob, FromBlob, ToBlob};
+use super::{Blob, ToBlob, TryFromBlob};
 
 /// A blob schema for an unknown blob.
 /// This blob schema is used as a fallback when the blob schema is not known.
@@ -23,9 +23,11 @@ impl BlobSchema for UnknownBlob {
     const BLOB_SCHEMA_ID: Id = id_hex!("EAB14005141181B0C10C4B5DD7985F8D");
 }
 
-impl FromBlob<UnknownBlob> for Bytes {
-    fn from_blob(blob: Blob<UnknownBlob>) -> Self {
-        blob.bytes
+impl TryFromBlob<UnknownBlob> for Bytes {
+    type Error = std::convert::Infallible;
+
+    fn try_from_blob(blob: Blob<UnknownBlob>) -> Result<Self, Self::Error> {
+        Ok(blob.bytes)
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,7 +32,7 @@ pub mod blobschemas;
 pub mod valueschemas;
 
 pub use crate::blob::BlobSchema;
-pub use crate::blob::{Blob, FromBlob, MemoryBlobStore, ToBlob, TryFromBlob, TryToBlob};
+pub use crate::blob::{Blob, MemoryBlobStore, ToBlob, TryFromBlob};
 pub use crate::id::{fucid, local_ids, rngid, ufoid, ExclusiveId, Id, IdOwner, RawId};
 pub use crate::namespace::NS;
 pub use crate::query::{

--- a/src/value.rs
+++ b/src/value.rs
@@ -370,7 +370,7 @@ pub trait ToValue<S: ValueSchema> {
 ///
 /// This is the counterpart to the [ToValue] trait.
 ///
-/// See [FromBlob](crate::blob::FromBlob) for the counterpart trait for blobs.
+/// See [TryFromBlob](crate::blob::TryFromBlob) for the counterpart trait for blobs.
 pub trait FromValue<'a, S: ValueSchema> {
     /// Convert the [Value] with a specific schema type to the Rust type.
     /// This might cause a panic if the conversion is not possible.
@@ -387,7 +387,6 @@ pub trait FromValue<'a, S: ValueSchema> {
 ///
 /// This is the counterpart to the [TryFromValue] trait.
 ///
-/// See [TryToBlob](crate::blob::TryToBlob) for the counterpart trait for blobs.
 pub trait TryToValue<S: ValueSchema> {
     type Error;
     /// Convert the Rust type to a [Value] with a specific schema type.


### PR DESCRIPTION
## Summary
- remove unused `FromBlob` and `TryToBlob` traits and document the change
- adjust blob schemas and prelude exports
- revert pointer lint fixes in branch

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails: could not compile `tribles` due to `dangerous_implicit_autorefs` lint)*

------
https://chatgpt.com/codex/tasks/task_e_6867d2dc1bf88322b51a5fba13c01de4