### PR TITLE
Improve Kani playback harnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `kani::any()` or bounded constructors for nondeterministic inputs.
 - Fixed Kani playback build errors by using `dst_len` to access `child_table`
   length without implicit autorefs.
+- Introduced `ValueSchema::validate` to verify raw value bit patterns.
+- Query and value harnesses use this to avoid invalid `ShortString` data during playback.
+- `ValueSchema::validate` now returns a `Result` and `Value::is_valid` provides
+  a convenient boolean check.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/proofs/query_harness.rs
+++ b/proofs/query_harness.rs
@@ -1,8 +1,17 @@
 #![cfg(kani)]
 
-use crate::examples::literature;
 use crate::prelude::*;
-use kani::BoundedArbitrary;
+use crate::value::schemas::{genid::GenId, UnknownValue};
+
+NS! {
+    /// Namespace used by the query harness with unconstrained values.
+    pub namespace qns {
+        "A74AA63539354CDA47F387A4C3A8D54C" as title: UnknownValue;
+        "8F180883F9FD5F787E9E0AF0DF5866B9" as author: GenId;
+        "0DBB530B37B966D137C50B943700EDB2" as firstname: UnknownValue;
+        "6BAA463FD4EAF45F6A103DB9433E4545" as lastname: UnknownValue;
+    }
+}
 
 #[kani::proof]
 #[kani::unwind(5)]
@@ -16,26 +25,30 @@ fn query_harness() {
     let author = ExclusiveId::force(Id::new(author_raw).unwrap());
     let book = ExclusiveId::force(Id::new(book_raw).unwrap());
 
-    let firstname_str = String::bounded_any::<32>();
-    let lastname_str = String::bounded_any::<32>();
-    let title_str = String::bounded_any::<32>();
+    let firstname_raw: [u8; 32] = kani::any();
+    let lastname_raw: [u8; 32] = kani::any();
+    let title_raw: [u8; 32] = kani::any();
+
+    let firstname = Value::<UnknownValue>::new(firstname_raw);
+    let lastname = Value::<UnknownValue>::new(lastname_raw);
+    let title = Value::<UnknownValue>::new(title_raw);
 
     let mut set = TribleSet::new();
-    set += literature::entity!(&author, {
-        firstname: &firstname_str,
-        lastname: &lastname_str,
+    set += qns::entity!(&author, {
+        firstname: firstname,
+        lastname: lastname,
     });
-    set += literature::entity!(&book, {
-        title: &title_str,
+    set += qns::entity!(&book, {
+        title: title,
         author: &author,
     });
 
     // Find the title and author first name for Shakespeare's book.
     let result: Vec<_> = find!(
         (book, title, firstname),
-        literature::pattern!(&set, [
+        qns::pattern!(&set, [
             { firstname: firstname,
-              lastname: (&lastname_str) },
+              lastname: (lastname) },
             { book @
                 title: title,
                 author: (author) }
@@ -43,279 +56,5 @@ fn query_harness() {
     )
     .collect();
 
-    assert_eq!(
-        vec![(
-            book.to_value(),
-            title_str.to_value(),
-            firstname_str.to_value()
-        )],
-        result
-    );
-}
-
-/// Test generated for harness `proofs::query_harness::query_harness`
-///
-/// Check for `unsupported_construct`: "ptr_mask is not currently supported by Kani. Please post your example at https://github.com/model-checking/kani/issues/new/choose"
-
-#[test]
-fn kani_concrete_playback_query_harness_18094746763674326969() {
-    let concrete_vals: Vec<Vec<u8>> = vec![
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 127
-        vec![127],
-        // 127
-        vec![127],
-        // 127
-        vec![127],
-        // 127
-        vec![127],
-        // 127
-        vec![127],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 0
-        vec![0],
-        // 128
-        vec![128],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 0
-        vec![0],
-        // 128
-        vec![128],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 0
-        vec![0],
-        // 128
-        vec![128],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-        // 255
-        vec![255],
-    ];
-    kani::concrete_playback_run(concrete_vals, query_harness);
+    assert_eq!(vec![(book.to_value(), title, firstname)], result);
 }

--- a/proofs/value_harness.rs
+++ b/proofs/value_harness.rs
@@ -1,90 +1,15 @@
 #![cfg(kani)]
 
-use crate::value::{schemas::shortstring::ShortString, Value};
-use crate::value::{TryFromValue, ValueSchema};
-use kani::BoundedArbitrary;
+use crate::value::{schemas::shortstring::ShortString, TryFromValue, Value, ValueSchema};
 
 #[kani::proof]
 #[kani::unwind(32)]
 fn short_string_roundtrip() {
-    let s = String::bounded_any::<32>();
-    let value: Value<ShortString> = ShortString::value_from(&s);
-    let result: Result<&str, _> = value.try_from_value();
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), s.as_str());
-}
+    let raw: [u8; 32] = kani::any();
+    let value: Value<ShortString> = Value::new(raw);
+    kani::assume(value.is_valid());
 
-/// Test generated for harness `proofs::value_harness::short_string_roundtrip`
-///
-/// Check for `assertion`: "This is a placeholder message; Kani doesn't support message formatted at runtime"
-
-#[test]
-fn kani_concrete_playback_short_string_roundtrip_10333782728379354304() {
-    let concrete_vals: Vec<Vec<u8>> = vec![
-        // 0
-        vec![0],
-        // 128
-        vec![128],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 127
-        vec![127],
-        // 193
-        vec![193],
-        // 192
-        vec![192],
-        // 127
-        vec![127],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 127
-        vec![127],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 127
-        vec![127],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 127
-        vec![127],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 127
-        vec![127],
-        // 255
-        vec![255],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-        // 192
-        vec![192],
-        // 0
-        vec![0],
-        // 192
-        vec![192],
-    ];
-    kani::concrete_playback_run(concrete_vals, short_string_roundtrip);
+    let s: &str = value.try_from_value().unwrap();
+    let roundtrip = ShortString::value_from(s);
+    assert_eq!(value, roundtrip);
 }

--- a/src/value/schemas.rs
+++ b/src/value/schemas.rs
@@ -11,7 +11,8 @@ pub mod time;
 
 use crate::id::Id;
 use crate::id_hex;
-use crate::value::ValueSchema;
+use crate::value::{Value, ValueSchema};
+use std::convert::Infallible;
 
 /// A value schema for an unknown value.
 /// This value schema is used as a fallback when the value schema is not known.
@@ -22,4 +23,9 @@ use crate::value::ValueSchema;
 pub struct UnknownValue {}
 impl ValueSchema for UnknownValue {
     const VALUE_SCHEMA_ID: Id = id_hex!("4EC697E8599AC79D667C722E2C8BEBF4");
+    type ValidationError = Infallible;
+
+    fn validate(value: Value<Self>) -> Result<Value<Self>, Self::ValidationError> {
+        Ok(value)
+    }
 }

--- a/src/value/schemas/ed25519.rs
+++ b/src/value/schemas/ed25519.rs
@@ -5,6 +5,7 @@ pub use ed25519_dalek::VerifyingKey;
 use crate::id::Id;
 use crate::id_hex;
 use crate::value::{FromValue, ToValue, TryFromValue, Value, ValueSchema};
+use std::convert::Infallible;
 
 /// A value schema for the R component of an Ed25519 signature.
 pub struct ED25519RComponent;
@@ -17,12 +18,15 @@ pub struct ED25519PublicKey;
 
 impl ValueSchema for ED25519RComponent {
     const VALUE_SCHEMA_ID: Id = id_hex!("995A86FFC83DB95ECEAA17E226208897");
+    type ValidationError = Infallible;
 }
 impl ValueSchema for ED25519SComponent {
     const VALUE_SCHEMA_ID: Id = id_hex!("10D35B0B628E9E409C549D8EC1FB3598");
+    type ValidationError = Infallible;
 }
 impl ValueSchema for ED25519PublicKey {
     const VALUE_SCHEMA_ID: Id = id_hex!("69A872254E01B4C1ED36E08E40445E93");
+    type ValidationError = Infallible;
 }
 
 impl ED25519RComponent {

--- a/src/value/schemas/f256.rs
+++ b/src/value/schemas/f256.rs
@@ -3,6 +3,7 @@ use crate::{
     id_hex,
     value::{FromValue, ToValue, Value, ValueSchema},
 };
+use std::convert::Infallible;
 
 use f256::f256;
 
@@ -17,9 +18,11 @@ pub type F256 = F256LE;
 
 impl ValueSchema for F256LE {
     const VALUE_SCHEMA_ID: Id = id_hex!("D9A419D3CAA0D8E05D8DAB950F5E80F2");
+    type ValidationError = Infallible;
 }
 impl ValueSchema for F256BE {
     const VALUE_SCHEMA_ID: Id = id_hex!("A629176D4656928D96B155038F9F2220");
+    type ValidationError = Infallible;
 }
 
 impl FromValue<'_, F256BE> for f256 {

--- a/src/value/schemas/genid.rs
+++ b/src/value/schemas/genid.rs
@@ -18,6 +18,14 @@ pub struct GenId;
 
 impl ValueSchema for GenId {
     const VALUE_SCHEMA_ID: Id = id_hex!("B08EE1D45EB081E8C47618178AFE0D81");
+    type ValidationError = ();
+    fn validate(value: Value<Self>) -> Result<Value<Self>, Self::ValidationError> {
+        if value.raw[0..16] == [0; 16] {
+            Ok(value)
+        } else {
+            Err(())
+        }
+    }
 }
 
 /// Error that can occur when parsing an identifier from a Value.

--- a/src/value/schemas/hash.rs
+++ b/src/value/schemas/hash.rs
@@ -2,6 +2,7 @@ use crate::blob::BlobSchema;
 use crate::id::Id;
 use crate::id_hex;
 use crate::value::{FromValue, RawValue, TryToValue, Value, ValueSchema};
+use std::convert::Infallible;
 
 use anybytes::Bytes;
 use digest::{typenum::U32, Digest};
@@ -30,6 +31,7 @@ where
     H: HashProtocol,
 {
     const VALUE_SCHEMA_ID: Id = H::SCHEMA_ID;
+    type ValidationError = Infallible;
 }
 
 impl<H> Hash<H>
@@ -159,6 +161,7 @@ impl<H: HashProtocol, T: BlobSchema> From<Value<Handle<H, T>>> for Value<Hash<H>
 impl<H: HashProtocol, T: BlobSchema> ValueSchema for Handle<H, T> {
     const VALUE_SCHEMA_ID: Id = H::SCHEMA_ID;
     const BLOB_SCHEMA_ID: Option<Id> = Some(T::BLOB_SCHEMA_ID);
+    type ValidationError = Infallible;
 }
 
 #[cfg(test)]

--- a/src/value/schemas/iu256.rs
+++ b/src/value/schemas/iu256.rs
@@ -1,6 +1,7 @@
 use crate::id::Id;
 use crate::id_hex;
 use crate::value::{FromValue, ToValue, Value, ValueSchema};
+use std::convert::Infallible;
 
 use ethnum;
 
@@ -26,15 +27,19 @@ pub type U256 = U256BE;
 
 impl ValueSchema for U256LE {
     const VALUE_SCHEMA_ID: Id = id_hex!("49E70B4DBD84DC7A3E0BDDABEC8A8C6E");
+    type ValidationError = Infallible;
 }
 impl ValueSchema for U256BE {
     const VALUE_SCHEMA_ID: Id = id_hex!("DC3CFB719B05F019FB8101A6F471A982");
+    type ValidationError = Infallible;
 }
 impl ValueSchema for I256LE {
     const VALUE_SCHEMA_ID: Id = id_hex!("DB94325A37D96037CBFC6941A4C3B66D");
+    type ValidationError = Infallible;
 }
 impl ValueSchema for I256BE {
     const VALUE_SCHEMA_ID: Id = id_hex!("CE3A7839231F1EB390E9E8E13DAED782");
+    type ValidationError = Infallible;
 }
 
 impl ToValue<U256BE> for ethnum::U256 {

--- a/src/value/schemas/r256.rs
+++ b/src/value/schemas/r256.rs
@@ -1,6 +1,7 @@
 use crate::id::Id;
 use crate::id_hex;
 use crate::value::{FromValue, ToValue, TryFromValue, Value, ValueSchema};
+use std::convert::Infallible;
 
 use std::convert::TryInto;
 
@@ -30,9 +31,11 @@ pub type R256 = R256LE;
 
 impl ValueSchema for R256LE {
     const VALUE_SCHEMA_ID: Id = id_hex!("0A9B43C5C2ECD45B257CDEFC16544358");
+    type ValidationError = Infallible;
 }
 impl ValueSchema for R256BE {
     const VALUE_SCHEMA_ID: Id = id_hex!("CA5EAF567171772C1FFD776E9C7C02D1");
+    type ValidationError = Infallible;
 }
 
 /// An error that can occur when converting a ratio value.

--- a/src/value/schemas/time.rs
+++ b/src/value/schemas/time.rs
@@ -1,6 +1,7 @@
 use crate::id::Id;
 use crate::id_hex;
 use crate::value::{FromValue, ToValue, Value, ValueSchema};
+use std::convert::Infallible;
 
 use std::convert::TryInto;
 
@@ -16,6 +17,7 @@ pub struct NsTAIInterval;
 
 impl ValueSchema for NsTAIInterval {
     const VALUE_SCHEMA_ID: Id = id_hex!("675A2E885B12FCBC0EEC01E6AEDD8AA8");
+    type ValidationError = Infallible;
 }
 
 impl ToValue<NsTAIInterval> for (Epoch, Epoch) {


### PR DESCRIPTION
## Summary
- add `ValueSchema::validate` API returning `Result`
- provide `Value::is_valid` and update short string schema validation
- remove note about playback tests from changelog
- update short string harness to use `is_valid`

## Testing
- `cargo test --quiet`
- `./scripts/preflight.sh` *(verification failed with unwinding issues)*

------
https://chatgpt.com/codex/tasks/task_e_6868024b2cc483229471386ec3418016