### PR TITLE
Add repository workspace documentation and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Documentation and examples for the repository API.
+- Test coverage for `branch_from` and `checkout_with_key`.
+- Git-based terminology notes in the repository guide and a clearer workspace example.
+- Expanded the repository example to store actual data and simplified the conflict loop.
+
 ### Changed
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.
 - Clarified need for duplicate `bucket_get_slot` check in `table_get_slot`.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The best way to get started is to read the module documentation of the `tribles`
 9. [Predefined Value Schemas](https://docs.rs/tribles/latest/tribles/value/schemas/index.html)
 10. [Predefined Blob Schemas](https://docs.rs/tribles/latest/tribles/blob/schemas/index.html)
 11. [Pile format and recovery](docs/pile.md)
+12. [Repository and Workspace](docs/repository.md)
 ## License
 
 Licensed under either of

--- a/docs/repository.md
+++ b/docs/repository.md
@@ -1,0 +1,66 @@
+# Repository and Workspace API
+
+The repository API offers a lightweight version control mechanism for
+trible data. A repository is backed by a pair of blob and branch stores
+that persist commits and branch metadata.
+Work is performed in a `Workspace` that tracks a branch head locally
+until the changes are pushed back to the repository.
+
+## Basic usage
+
+```rust
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use tribles::prelude::*;
+use tribles::repo::{memoryrepo::MemoryRepo, RepoPushResult, Repository};
+
+let storage = MemoryRepo::default();
+let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+let mut ws = repo.branch("main").expect("create branch");
+
+NS! {
+    pub namespace literature {
+        "8F180883F9FD5F787E9E0AF0DF5866B9" as author: GenId;
+        "0DBB530B37B966D137C50B943700EDB2" as firstname: ShortString;
+        "6BAA463FD4EAF45F6A103DB9433E4545" as lastname: ShortString;
+    }
+}
+let author = fucid();
+ws.commit(
+    literature::entity!(&author, {
+        firstname: "Frank",
+        lastname: "Herbert",
+    }),
+    Some("initial commit"),
+);
+
+match repo.push(&mut ws).expect("push") {
+    RepoPushResult::Success() => {}
+    RepoPushResult::Conflict(_) => panic!("unexpected conflict"),
+}
+```
+
+`checkout` creates a new workspace from an existing branch while
+`branch_from` can be used to start a new branch from a specific commit
+handle. See `examples/workspace.rs` for a more complete example.
+
+## Git parallels
+
+The API deliberately mirrors concepts from Git to make its usage familiar:
+
+- A `Repository` stores commits and branch metadata similar to a remote.
+- `Workspace` is akin to a working directory combined with an index. It
+  tracks changes against a branch head until you `push` them.
+- `branch` and `branch_from` correspond to creating new branches from the
+  current head or from a specific commit, respectively.
+- `push` updates the repository atomically. If the branch advanced in the
+  meantime, you receive a conflict workspace which can be merged before
+  retrying the push.
+- `checkout` is similar to cloning a branch into a new workspace.
+
+`checkout` uses the repository's default signing key for new commits. If you
+need to work with a different identity, the `_with_key` variants allow providing
+an explicit key when branching or checking out.
+
+These parallels should help readers leverage their Git knowledge when
+working with trible repositories.

--- a/examples/workspace.rs
+++ b/examples/workspace.rs
@@ -1,0 +1,18 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use tribles::prelude::*;
+use tribles::repo::{memoryrepo::MemoryRepo, RepoPushResult, Repository};
+
+fn main() {
+    let mut repo = Repository::new(MemoryRepo::default(), SigningKey::generate(&mut OsRng));
+
+    // create a new branch and add a commit
+    let mut ws = repo.branch("feature").expect("create branch");
+    ws.commit(TribleSet::new(), Some("start feature work"));
+
+    // push, merging on conflict
+    while let RepoPushResult::Conflict(mut other) = repo.push(&mut ws).expect("push") {
+        ws.merge(&mut other).expect("merge");
+    }
+    println!("pushed");
+}

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -1,0 +1,24 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use tribles::prelude::*;
+use tribles::repo::{commit, memoryrepo::MemoryRepo, Repository};
+
+#[test]
+fn branch_from_and_checkout_with_key() {
+    // prepare storage with an initial commit
+    let mut store = MemoryRepo::default();
+    let key = SigningKey::generate(&mut OsRng);
+    let commit_set = commit::commit(&key, [], None, None);
+    let initial = store.put(commit_set).unwrap();
+
+    let mut repo = Repository::new(store, key.clone());
+    let mut ws = repo.branch_from("feature", initial).expect("branch from");
+    ws.commit(TribleSet::new(), Some("work"));
+    repo.push(&mut ws).expect("push");
+
+    // checkout using a different key should succeed
+    let other_key = SigningKey::generate(&mut OsRng);
+    let branch_id = ws.branch_id();
+    repo.checkout_with_key(branch_id, other_key)
+        .expect("checkout");
+}


### PR DESCRIPTION
## Summary
- document repository/workspace API in `docs/repository.md`
- link to the new guide from the README
- add `examples/workspace.rs`
- test `branch_from` and `checkout_with_key`
- note changes in `CHANGELOG.md`
- refine docs with git parallels and clearer example

## Testing
- `cargo test`
- `./scripts/devtest.sh`
- `./scripts/preflight.sh` *(Kani produced warnings about unsupported constructs)*

------
https://chatgpt.com/codex/tasks/task_e_686aba43a2348322b66ea9757074c2ab