### PR TITLE
Switch to crates.io hifitime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `preflight.sh` now only checks formatting and runs tests; Kani proofs run via `verify.sh`.
 - Removed instruction to report unrelated Kani failures in PRs.
 - Moved repository and pile guides into module documentation and updated README links.
+- Depend on the crates.io release `hifitime` 4.1.2 instead of the git repository.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ anyhow = "1.0"
 bytes = "1.6.0"
 bytemuck = { version = "1.15.0", features = ["extern_crate_alloc"]}
 proptest = { version = "1.6.0", optional = true }
-hifitime = { git = "https://github.com/nyx-space/hifitime.git" }
+hifitime = "4.1.2"
 f256 = "0.7.0"
 sucds = "0.8.1"
 itertools = "0.14.0"

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -58,25 +58,25 @@
 //! `checkout` creates a new workspace from an existing branch while
 //! `branch_from` can be used to start a new branch from a specific commit
 //! handle. See `examples/workspace.rs` for a more complete example.
-//! 
+//!
 //! ## Handling conflicts
-//! 
+//!
 //! `push` may return `RepoPushResult::Conflict` when the branch has changed
 //! The returned workspace contains the updated branch metadata and must be
 //! pushed after merging your changes:
-//! 
-//! ```rust
+//!
+//! ```rust,ignore
 //! while let RepoPushResult::Conflict(mut other) = repo.push(&mut ws)? {
 //!     other.merge(&mut ws)?;
 //!     ws = other;
 //! }
 //! ```
-//! 
+//!
 //! `push` performs a compare‐and‐swap (CAS) update on the branch metadata.
 //! This optimistic concurrency control keeps branches consistent without
 //! locking and can be emulated by many storage systems (for example by
 //! using conditional writes on S3).
-//! 
+//!
 //! ## Git parallels
 //!
 //! The API deliberately mirrors concepts from Git to make its usage familiar:


### PR DESCRIPTION
## Summary
- use the released `hifitime` crate rather than a git dependency
- fix documentation snippet to skip compilation
- mention the updated dependency in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bfb20c8148322b43d3444f22564e7