### PR TITLE
Add rustfmt install step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `preflight.sh` now only checks formatting and runs tests; Kani proofs run via `verify.sh`.
 - Removed instruction to report unrelated Kani failures in PRs.
 - Moved repository and pile guides into module documentation and updated README links.
+- Simplified toolchain setup. Scripts install `rustfmt` and `cargo-kani` via
+  `cargo install` and rely on the system's default toolchain.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -4,11 +4,8 @@ set -euo pipefail
 # Move to repository root
 cd "$(dirname "$0")/.."
 
-# Ensure required tools are available
-if ! command -v rustfmt >/dev/null 2>&1; then
-  echo "rustfmt not found. Installing via rustup..."
-  rustup component add rustfmt
-fi
+# Ensure rustfmt is installed
+cargo install rustfmt --locked --quiet || true
 
 # Run formatting check and tests
 cargo fmt -- --check

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -4,11 +4,9 @@ set -euo pipefail
 # Move to repository root
 cd "$(dirname "$0")/.."
 
-# Ensure Kani verifier is available
-if ! cargo kani --version >/dev/null 2>&1; then
-  echo "cargo-kani not found. Installing Kani verifier..."
-  cargo install --locked kani-verifier
-fi
+# Ensure rustfmt and cargo-kani are installed
+cargo install rustfmt --locked --quiet || true
+cargo install kani-verifier --locked --quiet || true
 
 # Run all Kani proofs in the workspace. Additional stress or property tests can
 # be added here as needed.


### PR DESCRIPTION
## Summary
- simplify toolchain steps in helper scripts
- no longer use `rust-toolchain.toml`
- ensure `rustfmt` is installed for the active toolchain
- keep explicit `cargo-kani` install step

## Testing
- `./scripts/preflight.sh` *(fails: doctest in `src/repo.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_686bfca0e7208322ba22c2c28c1c27f8