### PR TITLE
Refactor objectstore iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restricted `PileSwap` and `PileAux` to crate visibility.
 - Repository guidelines now discourage asynchronous code in favor of
   synchronous implementations that can be parallelized.
+- Renamed `ObjectStoreRepo` to `ObjectStoreRemote` in the object-store backend.
+- Listing iterators for the object-store backend now stream directly from the
+  underlying store instead of collecting results in memory.
 
 ## [0.5.2] - 2025-06-30
 ### Added
 - Initial changelog file.
 - Repository guidelines now require documenting tasks in `CHANGELOG.md`.
+- Converted object-store backend to `BranchStore`/`BlobStore` API.
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -100,9 +100,9 @@
 //!
 pub mod branch;
 pub mod commit;
-//pub mod objectstore;
 pub mod hybridstore;
 pub mod memoryrepo;
+pub mod objectstore;
 pub mod pile;
 
 use std::{

--- a/src/repo/objectstore.rs
+++ b/src/repo/objectstore.rs
@@ -3,8 +3,11 @@ use std::convert::TryInto;
 use std::error::Error;
 use std::fmt;
 use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::Arc;
 
 use anybytes::Bytes;
+use futures::executor::{block_on, block_on_stream, BlockingStream};
 use futures::{Stream, StreamExt};
 
 use object_store::UpdateVersion;
@@ -14,7 +17,7 @@ use url::Url;
 use hex::FromHex;
 
 use crate::blob::schemas::UnknownBlob;
-use crate::blob::{Blob, BlobSchema};
+use crate::blob::{Blob, BlobSchema, ToBlob, TryFromBlob};
 use crate::id::{Id, RawId};
 use crate::prelude::blobschemas::SimpleArchive;
 use crate::value::{
@@ -22,9 +25,7 @@ use crate::value::{
     RawValue, Value, ValueSchema,
 };
 
-use super::{
-    BlobRepo, BranchRepo, BlobRepoGetOp, BlobRepoListOp, PushResult, BlobRepoPutOp,
-};
+use super::{BlobStore, BlobStoreGet, BlobStoreList, BlobStorePut, BranchStore, PushResult};
 
 const BRANCH_INFIX: &str = "branches";
 const BLOB_INFIX: &str = "blobs";
@@ -33,25 +34,306 @@ const BLOB_INFIX: &str = "blobs";
 ///
 /// All data is stored in an external service (e.g. S3, local filesystem) via
 /// the `object_store` crate.
-pub struct ObjectStoreRepo<H> {
-    store: Box<dyn ObjectStore>,
+pub struct ObjectStoreRemote<H> {
+    store: Arc<dyn ObjectStore>,
     prefix: Path,
     _hasher: PhantomData<H>,
 }
 
-impl<H> ObjectStoreRepo<H> {
+#[derive(Clone, Debug)]
+pub struct ObjectStoreReader<H> {
+    store: Arc<dyn ObjectStore>,
+    prefix: Path,
+    _hasher: PhantomData<H>,
+}
+
+pub struct BlockingIter<T> {
+    inner: BlockingStream<Pin<Box<dyn Stream<Item = T> + Send>>>,
+}
+
+impl<T> BlockingIter<T> {
+    fn new<S>(stream: S) -> Self
+    where
+        S: Stream<Item = T> + Send + 'static,
+    {
+        let boxed: Pin<Box<dyn Stream<Item = T> + Send>> = Box::pin(stream);
+        Self {
+            inner: block_on_stream(boxed),
+        }
+    }
+}
+
+impl<T> Iterator for BlockingIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<H> PartialEq for ObjectStoreReader<H> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.store, &other.store) && self.prefix == other.prefix
+    }
+}
+
+impl<H> Eq for ObjectStoreReader<H> {}
+
+impl<H> ObjectStoreRemote<H> {
     /// Creates a repository pointing at the object store described by `url`.
-    pub fn with_url(url: &Url) -> Result<ObjectStoreRepo<H>, object_store::Error> {
+    pub fn with_url(url: &Url) -> Result<ObjectStoreRemote<H>, object_store::Error> {
         let (store, path) = parse_url(&url)?;
-        Ok(ObjectStoreRepo {
-            store,
+        Ok(ObjectStoreRemote {
+            store: Arc::from(store),
             prefix: path,
             _hasher: PhantomData,
         })
     }
 }
 
-impl<H: HashProtocol> BlobRepo<H> for ObjectStoreRepo<H> {}
+impl<H> BlobStorePut<H> for ObjectStoreRemote<H>
+where
+    H: HashProtocol,
+{
+    type PutError = object_store::Error;
+
+    fn put<S, T>(&mut self, item: T) -> Result<Value<Handle<H, S>>, Self::PutError>
+    where
+        S: BlobSchema + 'static,
+        T: ToBlob<S>,
+        Handle<H, S>: ValueSchema,
+    {
+        let blob = item.to_blob();
+        let handle = blob.get_handle();
+        let path = self.prefix.child(BLOB_INFIX).child(hex::encode(handle.raw));
+        let bytes = bytes::Bytes::copy_from_slice(&blob.bytes);
+        let result = block_on(async {
+            self.store
+                .put_opts(&path, bytes.into(), PutMode::Create.into())
+                .await
+        });
+        match result {
+            Ok(_) | Err(object_store::Error::AlreadyExists { .. }) => Ok(handle),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl<H> BlobStore<H> for ObjectStoreRemote<H>
+where
+    H: HashProtocol,
+{
+    type Reader = ObjectStoreReader<H>;
+
+    fn reader(&mut self) -> Self::Reader {
+        ObjectStoreReader {
+            store: self.store.clone(),
+            prefix: self.prefix.clone(),
+            _hasher: PhantomData,
+        }
+    }
+}
+
+impl<H> BranchStore<H> for ObjectStoreRemote<H>
+where
+    H: HashProtocol,
+{
+    type BranchesError = ListBranchesErr;
+    type HeadError = PullBranchErr;
+    type UpdateError = PushBranchErr;
+
+    type ListIter<'a> = BlockingIter<Result<Id, Self::BranchesError>>;
+
+    fn branches<'a>(&'a self) -> Self::ListIter<'a> {
+        let prefix = self.prefix.child(BRANCH_INFIX);
+        let stream = self.store.list(Some(&prefix)).map(|r| match r {
+            Ok(meta) => {
+                let name = meta
+                    .location
+                    .filename()
+                    .ok_or(ListBranchesErr::NotAFile("no filename"))?;
+                let digest = RawId::from_hex(name).map_err(|e| ListBranchesErr::BadNameHex(e))?;
+                let Some(id) = Id::new(digest) else {
+                    return Err(ListBranchesErr::BadId);
+                };
+                Ok(id)
+            }
+            Err(e) => Err(ListBranchesErr::List(e)),
+        });
+        BlockingIter::new(stream)
+    }
+
+    fn head(&self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError> {
+        let path = self.prefix.child(BRANCH_INFIX).child(hex::encode(&id));
+        let result = block_on(async { self.store.get(&path).await });
+        match result {
+            Ok(object) => {
+                let bytes = block_on(object.bytes())?;
+                let value = (&bytes[..]).try_into()?;
+                Ok(Some(Value::new(value)))
+            }
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(e) => Err(PullBranchErr::StoreErr(e)),
+        }
+    }
+
+    fn update(
+        &mut self,
+        id: Id,
+        old: Option<Value<Handle<H, SimpleArchive>>>,
+        new: Value<Handle<H, SimpleArchive>>,
+    ) -> Result<PushResult<H>, Self::UpdateError> {
+        let path = self.prefix.child(BRANCH_INFIX).child(hex::encode(&id));
+        let new_bytes = bytes::Bytes::copy_from_slice(&new.raw);
+        if let Some(old_hash) = old {
+            let mut result = block_on(async { self.store.get(&path).await });
+            loop {
+                match result {
+                    Ok(obj) => {
+                        let version = UpdateVersion {
+                            e_tag: obj.meta.e_tag.clone(),
+                            version: obj.meta.version.clone(),
+                        };
+                        let stored_bytes = block_on(obj.bytes())?;
+                        let stored_value = (&stored_bytes[..]).try_into()?;
+                        let stored_hash = Value::new(stored_value);
+                        if old_hash != stored_hash {
+                            return Ok(PushResult::Conflict(Some(stored_hash)));
+                        }
+                        match block_on(async {
+                            self.store
+                                .put_opts(
+                                    &path,
+                                    new_bytes.clone().into(),
+                                    PutMode::Update(version).into(),
+                                )
+                                .await
+                        }) {
+                            Ok(_) => return Ok(PushResult::Success()),
+                            Err(object_store::Error::Precondition { .. }) => {
+                                result = block_on(async { self.store.get(&path).await });
+                                continue;
+                            }
+                            Err(e) => return Err(PushBranchErr::StoreErr(e)),
+                        }
+                    }
+                    Err(object_store::Error::NotFound { .. }) => {
+                        return Ok(PushResult::Conflict(None));
+                    }
+                    Err(e) => return Err(PushBranchErr::StoreErr(e)),
+                }
+            }
+        } else {
+            loop {
+                match block_on(async {
+                    self.store
+                        .put_opts(&path, new_bytes.clone().into(), PutMode::Create.into())
+                        .await
+                }) {
+                    Ok(_) => return Ok(PushResult::Success()),
+                    Err(object_store::Error::AlreadyExists { .. }) => {
+                        let result = block_on(async { self.store.get(&path).await });
+                        match result {
+                            Ok(obj) => {
+                                let bytes = block_on(obj.bytes())?;
+                                let value = (&bytes[..]).try_into()?;
+                                return Ok(PushResult::Conflict(Some(Value::new(value))));
+                            }
+                            Err(object_store::Error::NotFound { .. }) => continue,
+                            Err(e) => return Err(PushBranchErr::StoreErr(e)),
+                        }
+                    }
+                    Err(e) => return Err(PushBranchErr::StoreErr(e)),
+                }
+            }
+        }
+    }
+}
+
+impl<H> ObjectStoreReader<H> {
+    fn blob_path(&self, handle_hex: String) -> Path {
+        self.prefix.child(BLOB_INFIX).child(handle_hex)
+    }
+}
+
+impl<H> BlobStoreList<H> for ObjectStoreReader<H>
+where
+    H: HashProtocol,
+{
+    type Err = ListBlobsErr;
+    type Iter<'a> = BlockingIter<Result<Value<Handle<H, UnknownBlob>>, Self::Err>>;
+
+    fn blobs<'a>(&'a self) -> Self::Iter<'a> {
+        let prefix = self.prefix.child(BLOB_INFIX);
+        let stream = self.store.list(Some(&prefix)).map(|r| match r {
+            Ok(meta) => {
+                let blob_name = meta
+                    .location
+                    .filename()
+                    .ok_or(ListBlobsErr::NotAFile("no filename"))?;
+                let digest =
+                    RawValue::from_hex(blob_name).map_err(|e| ListBlobsErr::BadNameHex(e))?;
+                Ok(Value::new(digest))
+            }
+            Err(e) => Err(ListBlobsErr::List(e)),
+        });
+        BlockingIter::new(stream)
+    }
+}
+
+#[derive(Debug)]
+pub enum GetBlobErr<E: Error> {
+    Store(object_store::Error),
+    Conversion(E),
+}
+
+impl<E: Error> fmt::Display for GetBlobErr<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Store(e) => write!(f, "object store error: {}", e),
+            Self::Conversion(e) => write!(f, "conversion error: {}", e),
+        }
+    }
+}
+
+impl<E: Error> Error for GetBlobErr<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Store(e) => Some(e),
+            Self::Conversion(_) => None,
+        }
+    }
+}
+
+impl<E: Error> From<object_store::Error> for GetBlobErr<E> {
+    fn from(e: object_store::Error) -> Self {
+        Self::Store(e)
+    }
+}
+
+impl<H> BlobStoreGet<H> for ObjectStoreReader<H>
+where
+    H: HashProtocol,
+{
+    type GetError<E: Error> = GetBlobErr<E>;
+
+    fn get<T, S>(
+        &self,
+        handle: Value<Handle<H, S>>,
+    ) -> Result<T, Self::GetError<<T as TryFromBlob<S>>::Error>>
+    where
+        S: BlobSchema + 'static,
+        T: TryFromBlob<S>,
+        Handle<H, S>: ValueSchema,
+    {
+        let path = self.blob_path(hex::encode(handle.raw));
+        let object = block_on(async { self.store.get(&path).await })?;
+        let bytes = block_on(object.bytes())?;
+        let bytes: Bytes = bytes.into();
+        let blob: Blob<S> = Blob::new(bytes);
+        blob.try_from_blob().map_err(|e| GetBlobErr::Conversion(e))
+    }
+}
 
 #[derive(Debug)]
 pub enum ListBlobsErr {
@@ -90,87 +372,6 @@ impl fmt::Display for ListBranchesErr {
     }
 }
 impl Error for ListBranchesErr {}
-
-impl<H> BlobRepoListOp<H> for ObjectStoreRepo<H>
-where
-    H: HashProtocol,
-{
-    type Err = ListBlobsErr;
-
-    fn list<'a>(&'a self) -> impl Stream<Item = Result<Value<Handle<H, UnknownBlob>>, Self::Err>> {
-        self.store
-            .list(Some(&self.prefix.child(BLOB_INFIX)))
-            .map(|r| match r {
-                Ok(meta) => {
-                    let blob_name = meta
-                        .location
-                        .filename()
-                        .ok_or(ListBlobsErr::NotAFile("no filename"))?;
-                    let digest =
-                        RawValue::from_hex(blob_name).map_err(|e| ListBlobsErr::BadNameHex(e))?;
-                    Ok(Value::new(digest))
-                }
-                Err(e) => Err(ListBlobsErr::List(e)),
-            })
-            .boxed()
-    }
-}
-
-impl<H> BlobRepoGetOp<H> for ObjectStoreRepo<H>
-where
-    H: HashProtocol,
-{
-    type Err = object_store::Error;
-
-    fn get<T>(
-        &self,
-        handle: Value<Handle<H, T>>,
-    ) -> impl std::future::Future<Output = Result<Blob<T>, Self::Err>>
-    where
-        T: BlobSchema,
-    {
-        async move {
-            let path = self.prefix.child(BLOB_INFIX).child(hex::encode(handle.raw));
-            let result = self.store.get(&path).await?;
-            let object = result.bytes().await?;
-            let bytes: Bytes = object.into();
-            Ok(Blob::new(bytes))
-        }
-    }
-}
-
-impl<H> BlobRepoPutOp<H> for ObjectStoreRepo<H>
-where
-    H: HashProtocol,
-{
-    type Err = object_store::Error;
-
-    fn put<T>(
-        &self,
-        blob: Blob<T>,
-    ) -> Result<Value<Handle<H, T>>, Self::Err>
-    where
-        T: BlobSchema,
-        Handle<H, T>: ValueSchema,
-    {
-        async move {
-            let handle = blob.get_handle();
-            let path = self.prefix.child(BLOB_INFIX).child(hex::encode(handle.raw));
-            let put_result = self
-                .store
-                .put_opts(
-                    &path,
-                    bytes::Bytes::copy_from_slice(&blob.bytes).into(), // This copy could be avoided if bytes::Bytes was open...
-                    PutMode::Create.into(),
-                )
-                .await;
-            match put_result {
-                Ok(_) | Err(object_store::Error::AlreadyExists { .. }) => Ok(handle),
-                Err(e) => Err(e),
-            }
-        }
-    }
-}
 
 #[derive(Debug)]
 pub enum PullBranchErr {
@@ -227,127 +428,5 @@ impl From<object_store::Error> for PushBranchErr {
 impl From<TryFromSliceError> for PushBranchErr {
     fn from(err: TryFromSliceError) -> Self {
         Self::ValidationErr(err)
-    }
-}
-
-impl<H: HashProtocol> BranchRepo<H> for ObjectStoreRepo<H> {
-    type ListErr = ListBranchesErr;
-    type PushErr = PushBranchErr;
-    type PullErr = PullBranchErr;
-
-    fn list<'a>(&'a self) -> impl Stream<Item = Result<Id, Self::ListErr>> {
-        self.store
-            .list(Some(&self.prefix.child(BRANCH_INFIX)))
-            .map(|r| match r {
-                Ok(meta) => {
-                    let branch_name = meta
-                        .location
-                        .filename()
-                        .ok_or(ListBranchesErr::NotAFile("no filename"))?;
-                    let digest =
-                        RawId::from_hex(branch_name).map_err(|e| ListBranchesErr::BadNameHex(e))?;
-                    let Some(new_id) = Id::new(digest) else {
-                        return Err(ListBranchesErr::BadId);
-                    };
-                    Ok(new_id)
-                }
-                Err(e) => Err(ListBranchesErr::List(e)),
-            })
-            .boxed()
-    }
-
-    async fn pull(&self, branch: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::PullErr> {
-        let branch_name = hex::encode(&branch);
-        let path = self.prefix.child(BRANCH_INFIX).child(branch_name);
-        let result = self.store.get(&path).await;
-        match result {
-            Ok(result) => {
-                let bytes = result.bytes().await?;
-                let value = (&bytes[..]).try_into()?;
-                Ok(Some(Value::new(value)))
-            }
-            Err(object_store::Error::NotFound { .. }) => Ok(None),
-            Err(e) => Err(e)?,
-        }
-    }
-
-    async fn push(
-        &self,
-        branch_id: Id,
-        old_hash: Option<Value<Handle<H, SimpleArchive>>>,
-        new_hash: Value<Handle<H, SimpleArchive>>,
-    ) -> Result<PushResult<H>, Self::PushErr> {
-        let branch_name = hex::encode(&branch_id);
-        let path = &self.prefix.child(BRANCH_INFIX).child(branch_name);
-
-        let new_bytes = bytes::Bytes::copy_from_slice(&new_hash.raw);
-
-        if let Some(old_hash) = old_hash {
-            let mut result = self.store.get(path).await;
-            loop {
-                // Attempt to commit
-                match result {
-                    Ok(ok_result) => {
-                        // Save version information fetched
-                        let version = UpdateVersion {
-                            e_tag: ok_result.meta.e_tag.clone(),
-                            version: ok_result.meta.version.clone(),
-                        };
-                        let stored_bytes = ok_result.bytes().await?;
-                        let stored_value = (&stored_bytes[..]).try_into()?;
-                        let stored_hash = Value::new(stored_value);
-                        if old_hash != stored_hash {
-                            return Ok(PushResult::Conflict(Some(stored_hash)));
-                        }
-                        match self
-                            .store
-                            .put_opts(
-                                &path,
-                                new_bytes.clone().into(),
-                                PutMode::Update(version).into(),
-                            )
-                            .await
-                        {
-                            Ok(_) => return Ok(PushResult::Success()), // Successfully committed
-                            Err(object_store::Error::Precondition { .. }) => {
-                                result = self.store.get(&path).await;
-                                continue;
-                            }
-                            Err(e) => return Err(e.into()),
-                        }
-                    }
-                    Err(object_store::Error::NotFound { .. }) => {
-                        return Ok(PushResult::Conflict(None));
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            }
-        } else {
-            loop {
-                // Attempt to commit
-                match self
-                    .store
-                    .put_opts(&path, new_bytes.clone().into(), PutMode::Create.into())
-                    .await
-                {
-                    Ok(_) => return Ok(PushResult::Success()), // Successfully committed
-                    Err(object_store::Error::AlreadyExists { .. }) => {
-                        let result = self.store.get(path).await;
-                        match result {
-                            Ok(result) => {
-                                let stored_bytes = result.bytes().await?;
-                                let stored_value = (&stored_bytes[..]).try_into()?;
-                                return Ok(PushResult::Conflict(Some(Value::new(stored_value))));
-                            }
-                            Err(object_store::Error::NotFound { .. }) => {
-                                continue; // Object no longer exists try again
-                            }
-                            Err(e) => return Err(e.into()),
-                        }
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- stream object store lists via new `BlockingIter` instead of collecting
- update changelog to note streaming iterators

## Testing
- `./scripts/devtest.sh`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d2aee8fb08322ab698aad6e20fb7b