### PR TITLE
Simplify push return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `ObjectStoreRepo` to `ObjectStoreRemote` in the object-store backend.
 - Listing iterators for the object-store backend now stream directly from the
   underlying store instead of collecting results in memory.
+- `Repository::push` now returns `Option<Workspace>` instead of the custom
+  `RepoPushResult` enum, simplifying conflict handling.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/examples/repo.rs
+++ b/examples/repo.rs
@@ -2,7 +2,7 @@ use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::examples::literature;
 use tribles::prelude::*;
-use tribles::repo::{RepoPushResult, Repository};
+use tribles::repo::Repository;
 
 fn main() {
     const MAX_PILE_SIZE: usize = 1 << 20;
@@ -31,12 +31,12 @@ fn main() {
     ws2.commit(change, Some("add bob"));
 
     match repo.push(&mut ws2).expect("push ws2") {
-        RepoPushResult::Success() => println!("Push ws2 succeeded"),
-        RepoPushResult::Conflict(mut other) => loop {
+        None => println!("Push ws2 succeeded"),
+        Some(mut other) => loop {
             other.merge(&mut ws2).expect("merge");
             match repo.push(&mut other).expect("push conflict") {
-                RepoPushResult::Success() => break,
-                RepoPushResult::Conflict(next) => other = next,
+                None => break,
+                Some(next) => other = next,
             }
         },
     }

--- a/examples/workspace.rs
+++ b/examples/workspace.rs
@@ -1,7 +1,7 @@
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{memoryrepo::MemoryRepo, RepoPushResult, Repository};
+use tribles::repo::{memoryrepo::MemoryRepo, Repository};
 
 fn main() {
     let mut repo = Repository::new(MemoryRepo::default(), SigningKey::generate(&mut OsRng));
@@ -11,7 +11,7 @@ fn main() {
     workspace.commit(TribleSet::new(), Some("start feature work"));
 
     // attempt to push, merging conflicts before retrying
-    while let RepoPushResult::Conflict(mut incoming) = repo.push(&mut workspace).expect("push") {
+    while let Some(mut incoming) = repo.push(&mut workspace).expect("push") {
         // merge our local changes into the conflicting workspace
         incoming.merge(&mut workspace).expect("merge");
         // push the merged workspace on the next iteration

--- a/tests/objectstore_repo.rs
+++ b/tests/objectstore_repo.rs
@@ -1,7 +1,7 @@
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{self, objectstore::ObjectStoreRemote, RepoPushResult, Repository};
+use tribles::repo::{self, objectstore::ObjectStoreRemote, Repository};
 use tribles::value::schemas::hash::Blake3;
 use url::Url;
 
@@ -26,7 +26,7 @@ fn objectstore_workspace_commit_updates_head() {
     ws.commit(TribleSet::new(), Some("change"));
 
     match repo.push(&mut ws).expect("push") {
-        RepoPushResult::Success() => {}
+        None => {}
         _ => panic!("push failed"),
     }
 }
@@ -63,19 +63,19 @@ fn objectstore_push_and_merge_conflict_resolution() {
     ws2.commit(TribleSet::new(), Some("second"));
 
     match repo.push(&mut ws1).expect("push") {
-        RepoPushResult::Success() => {}
+        None => {}
         _ => panic!("expected success"),
     }
 
     let mut conflict_ws = match repo.push(&mut ws2).expect("push") {
-        RepoPushResult::Conflict(ws) => ws,
+        Some(ws) => ws,
         _ => panic!("expected conflict"),
     };
 
     conflict_ws.merge(&mut ws2).unwrap();
 
     match repo.push(&mut conflict_ws).expect("push") {
-        RepoPushResult::Success() => {}
+        None => {}
         _ => panic!("expected success after merge"),
     }
 }

--- a/tests/push_merge.rs
+++ b/tests/push_merge.rs
@@ -1,7 +1,7 @@
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{memoryrepo::MemoryRepo, RepoPushResult, Repository};
+use tribles::repo::{memoryrepo::MemoryRepo, Repository};
 
 #[test]
 fn push_and_merge_conflict_resolution() {
@@ -15,19 +15,19 @@ fn push_and_merge_conflict_resolution() {
     ws2.commit(TribleSet::new(), Some("second"));
 
     match repo.push(&mut ws1).expect("push") {
-        RepoPushResult::Success() => {}
+        None => {}
         _ => panic!("expected success"),
     }
 
     let mut conflict_ws = match repo.push(&mut ws2).expect("push") {
-        RepoPushResult::Conflict(ws) => ws,
+        Some(ws) => ws,
         _ => panic!("expected conflict"),
     };
 
     conflict_ws.merge(&mut ws2).unwrap();
 
     match repo.push(&mut conflict_ws).expect("push") {
-        RepoPushResult::Success() => {}
+        None => {}
         _ => panic!("expected success after merge"),
     }
 }

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,7 +1,7 @@
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{memoryrepo::MemoryRepo, RepoPushResult, Repository};
+use tribles::repo::{memoryrepo::MemoryRepo, Repository};
 
 #[test]
 fn workspace_commit_updates_head() {
@@ -12,7 +12,7 @@ fn workspace_commit_updates_head() {
     ws.commit(TribleSet::new(), Some("change"));
 
     match repo.push(&mut ws) {
-        Ok(RepoPushResult::Success()) => {}
+        Ok(None) => {}
         Ok(_) | Err(_) => panic!("push failed"),
     }
 }


### PR DESCRIPTION
## Summary
- remove `RepoPushResult` enum
- return `Option<Workspace>` from `Repository::push`
- update examples, tests, and docs
- note change in `CHANGELOG`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873b3bcc3208322a3aa57d9dbca6efb