### PR TITLE
Improve book documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with `.expect()` in object store tests.
 - Initial scaffold for a narrative "Tribles Book" documentation.
 - Build script `build_book.sh` and CI workflow to publish the mdBook.
+- Expanded the introduction and philosophy sections of the Tribles Book and
+  documented how to install `mdbook`.
 
 ### Changed
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ fn main() -> std::io::Result<()> {
 ## Tribles Book
 
 For a step-by-step narrative guide, see the [Tribles Book](book/README.md).
+To build the HTML locally, first install `mdbook` with `cargo install mdbook`
+and then run:
+
+```bash
+./scripts/build_book.sh
+```
 
 # Learn More
 

--- a/book/README.md
+++ b/book/README.md
@@ -1,7 +1,8 @@
 # Tribles Book
 
 This directory contains a work-in-progress guide built with
-[`mdBook`](https://rust-lang.github.io/mdBook/). To build the HTML
+[`mdBook`](https://rust-lang.github.io/mdBook/). If you don't have
+`mdbook` installed yet, run `cargo install mdbook`. To build the HTML
 locally, run:
 
 ```bash

--- a/book/src/deep-dive/philosophy.md
+++ b/book/src/deep-dive/philosophy.md
@@ -3,3 +3,13 @@
 This section collects the more detailed discussions around the design of
 Trible Space and the reasoning behind certain choices. It is meant as an
 optional read for the curious.
+
+We prioritise a simple and predictable system over clever heuristics. Each
+component should be understandable on its own and interact cleanly with the
+rest of the stack.
+
+Developer experience is equally important. APIs aim to be straightforward and
+use synchronous building blocks that can be composed as needed.
+
+Finally, we strive for soundness and performance. Safety checks guard against
+invalid data while efficient data structures keep the core fast.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -4,3 +4,12 @@ Welcome to the **Tribles Book**. This guide provides a gentle introduction to
 Trible Space, its design goals and how to use the `tribles` crate.  The aim is to
 present a clear narrative for newcomers while linking to in‑depth reference
 material for those who want to dig deeper.
+
+Trible Space combines ideas from databases and version control. Data is stored
+in small immutable blobs that can live in memory, on disk or inside remote
+object stores without conversion. Cryptographic identifiers ensure integrity and
+enable efficient sharing across systems.
+
+While this book walks you through the basics, the crate documentation offers a
+complete API reference. Use the links throughout the text to jump directly to
+the modules that interest you.


### PR DESCRIPTION
## Summary
- document how to install `mdbook`
- expand the introduction and philosophy chapters
- link build instructions in the README
- note docs in CHANGELOG

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873c96374c48322944761681686d559