### PR TITLE
Update preflight book check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Repository::push` now returns `Option<Workspace>` instead of the custom
   `RepoPushResult` enum, simplifying conflict handling.
 - Split identifier and trible structure discussions into dedicated deep-dive book chapters.
+- `preflight.sh` now verifies that the mdBook documentation builds successfully.
+- Fixed book `SUMMARY.md` so preflight passes without parse errors.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,7 +2,7 @@
 
 - [Introduction](introduction.md)
 - [Getting Started](getting-started.md)
-- Deep Dive
+- [Deep Dive](deep-dive/README.md)
   - [Philosophy](deep-dive/philosophy.md)
   - [Identifiers](deep-dive/identifiers.md)
   - [Trible Structure](deep-dive/trible-structure.md)

--- a/book/src/deep-dive/README.md
+++ b/book/src/deep-dive/README.md
@@ -1,0 +1,3 @@
+# Deep Dive
+
+This section contains in-depth discussions about Trible Space internals.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -7,6 +7,12 @@ cd "$(dirname "$0")/.."
 # Ensure rustfmt is installed
 rustup component add rustfmt
 
-# Run formatting check and tests
+# Ensure mdBook is installed
+if ! command -v mdbook >/dev/null 2>&1; then
+    cargo install mdbook
+fi
+
+# Run formatting check, tests, and build the book
 cargo fmt -- --check
 cargo test
+./scripts/build_book.sh


### PR DESCRIPTION
## Summary
- install mdBook and build docs in preflight
- note script change in CHANGELOG
- fix book build by linking deep-dive section properly

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6873c83144c88322b23443470f5287c5