### PR TITLE
Add local development guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build script `build_book.sh` and CI workflow to publish the mdBook.
 - Expanded the introduction and philosophy sections of the Tribles Book and
   documented how to install `mdbook`.
+- Added a "Developing Locally" chapter and linked it from the README and book introduction.
 
 ### Changed
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ and then run:
 ./scripts/build_book.sh
 ```
 
+For details on setting up a development environment, see [Developing Locally](book/src/contributing.md).
+
 # Learn More
 
 The best way to get started is to read the module documentation of the `tribles` crate. The following links provide an overview of the most important modules, in an order where you can start with the most basic concepts and work your way up to more advanced topics:

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Introduction](introduction.md)
 - [Getting Started](getting-started.md)
+- [Developing Locally](contributing.md)
 - Deep Dive
   - [Philosophy](deep-dive/philosophy.md)
   - [Identifiers](deep-dive/identifiers.md)

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -1,0 +1,7 @@
+# Developing Locally
+
+To build and test Tribles yourself you need a recent Rust toolchain. Install it from [rustup.rs](https://rustup.rs/).
+
+Run `./scripts/preflight.sh` from the repository root to format the code and execute the full test suite. For quick iterations `./scripts/devtest.sh` runs only the tests.
+
+If you want to render this book locally first install `mdbook` with `cargo install mdbook` and then run `./scripts/build_book.sh`.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -13,3 +13,5 @@ enable efficient sharing across systems.
 While this book walks you through the basics, the crate documentation offers a
 complete API reference. Use the links throughout the text to jump directly to
 the modules that interest you.
+
+If you would like to work on Tribles yourself, check out [Developing Locally](contributing.md).


### PR DESCRIPTION
## Summary
- document how to work on the project in `book/src/contributing.md`
- link the guide from the README and book introduction
- register the new chapter in `SUMMARY.md`
- note the addition in `CHANGELOG.md`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873d056e10c8322ace12b399b916457