### PR TITLE
Implement direct put method on Workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split identifier and trible structure discussions into dedicated deep-dive book chapters.
 - `preflight.sh` now verifies that the mdBook documentation builds successfully.
 - Fixed book `SUMMARY.md` so preflight passes without parse errors.
+- `Workspace` now exposes a `put` method for adding blobs, replacing the old
+  `add_blob` helper. The method returns the stored blob's handle directly since
+  the underlying store cannot fail.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -783,13 +783,16 @@ impl<Blobs: BlobStore<Blake3>> Workspace<Blobs> {
     pub fn branch_id(&self) -> Id {
         self.base_branch_id
     }
+
     /// Adds a blob to the workspace's local blob store.
-    /// Returns the handle of the blob as stored locally.
-    pub fn add_blob<T>(&mut self, blob: Blob<T>) -> Value<Handle<Blake3, T>>
+    /// Mirrors [`BlobStorePut::put`](crate::repo::BlobStorePut) for ease of use.
+    pub fn put<S, T>(&mut self, item: T) -> Value<Handle<Blake3, S>>
     where
-        T: BlobSchema + 'static,
+        S: BlobSchema + 'static,
+        T: ToBlob<S>,
+        Handle<Blake3, S>: ValueSchema,
     {
-        self.local_blobs.put(blob).unwrap()
+        self.local_blobs.put(item).expect("infallible blob put")
     }
 
     /// Performs a commit in the workspace.


### PR DESCRIPTION
## Summary
- replace `add_blob` helper with a `put` method on `Workspace`
- make `Workspace::put` return the stored handle directly
- update changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6873ee0f1b108322ab7b72a54022a58c