### PR TITLE
Add book chapter on schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository guide.
 - Property tests for `ufoid` randomness and timestamp rollover.
 - Further clarified `timestamp_distance` documentation that it only works with
+- Documentation for built-in schemas and how to create your own.
   timestamps younger than the ~50-day rollover period.
 - Added `HybridStore` to combine separate blob and branch stores.
 - Added tests for the `ObjectStoreRemote` repository using the in-memory

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,3 +6,4 @@
   - [Philosophy](deep-dive/philosophy.md)
   - [Identifiers](deep-dive/identifiers.md)
   - [Trible Structure](deep-dive/trible-structure.md)
+- [Schemas](schemas.md)

--- a/book/src/schemas.md
+++ b/book/src/schemas.md
@@ -1,0 +1,63 @@
+# Schemas
+
+Trible Space stores data in strongly typed values and blobs.  A *schema*
+describes a language‑agnostic data type with a specific byte representation:
+exactly 32&nbsp;bytes for a [`Value`] and an arbitrary number of bytes for a
+[`Blob`].  These abstract types can be converted to the concrete types of your
+application but decouple stored data from any particular implementation.  This
+also means you can refactor to new libraries or frameworks without rewriting
+what's already stored. The crate ships with a collection of ready‑made schemas located in
+[`src/value/schemas`](../src/value/schemas) and
+[`src/blob/schemas`](../src/blob/schemas).
+
+## Built‑in value schemas
+
+The crate provides the following value schemas out of the box:
+- `GenId` &ndash; an abstract 128 bit identifier.
+- `ShortString` &ndash; a UTF-8 string up to 32 bytes.
+- `U256BE` / `U256LE` &ndash; 256-bit unsigned integers.
+- `I256BE` / `I256LE` &ndash; 256-bit signed integers.
+- `R256BE` / `R256LE` &ndash; 256-bit rational numbers.
+- `F256BE` / `F256LE` &ndash; 256-bit floating point numbers.
+- `Hash` and `Handle` &ndash; cryptographic digests and blob handles (see [`hash.rs`](../src/value/schemas/hash.rs)).
+- `ED25519RComponent`, `ED25519SComponent` and `ED25519PublicKey` &ndash; signature fields and keys.
+- `NsTAIInterval` to encode time intervals.
+- `UnknownValue` as a fallback when no specific schema is known.
+
+```rust
+use tribles::value::schemas::shortstring::ShortString;
+use tribles::value::{ToValue, ValueSchema};
+
+let v = "hi".to_value::<ShortString>();
+assert_eq!(v.schema_id(), ShortString::VALUE_SCHEMA_ID);
+```
+
+## Built‑in blob schemas
+
+The crate also ships with these blob schemas:
+
+- `LongString` for arbitrarily long UTF‑8 strings.
+- `SimpleArchive` which stores a raw sequence of tribles.
+- `SuccinctArchive` providing a compressed index for offline queries.
+- `UnknownBlob` for data of unknown type.
+
+```rust
+use tribles::blob::schemas::longstring::LongString;
+use tribles::blob::{ToBlob, BlobSchema};
+
+let b = "example".to_blob::<LongString>();
+assert_eq!(LongString::BLOB_SCHEMA_ID, b.schema_id());
+```
+
+## Defining new schemas
+
+Custom formats implement [`ValueSchema`] or [`BlobSchema`].  A unique identifier
+serves as the schema ID.  The example below defines a little-endian `u64` value
+schema and a simple blob schema for arbitrary bytes.
+
+```rust
+{{#include ../examples/custom_schema.rs:beginning:ending}}
+```
+
+See [`examples/custom_schema.rs`](../examples/custom_schema.rs) for the full
+source.

--- a/examples/custom_schema.rs
+++ b/examples/custom_schema.rs
@@ -1,0 +1,51 @@
+use anybytes::Bytes;
+use std::convert::Infallible;
+use tribles::blob::{Blob, BlobSchema, ToBlob, TryFromBlob};
+use tribles::id::{id_hex, Id};
+use tribles::value::{FromValue, ToValue, Value, ValueSchema, VALUE_LEN};
+
+// beginning
+
+pub struct U64LE;
+
+impl ValueSchema for U64LE {
+    const VALUE_SCHEMA_ID: Id = id_hex!("0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A");
+    type ValidationError = Infallible;
+}
+
+impl ToValue<U64LE> for u64 {
+    fn to_value(self) -> Value<U64LE> {
+        let mut raw = [0u8; VALUE_LEN];
+        raw[..8].copy_from_slice(&self.to_le_bytes());
+        Value::new(raw)
+    }
+}
+
+impl FromValue<'_, U64LE> for u64 {
+    fn from_value(v: &Value<U64LE>) -> Self {
+        u64::from_le_bytes(v.raw[..8].try_into().unwrap())
+    }
+}
+
+pub struct BytesBlob;
+
+impl BlobSchema for BytesBlob {
+    const BLOB_SCHEMA_ID: Id = id_hex!("B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0");
+}
+
+impl ToBlob<BytesBlob> for Bytes {
+    fn to_blob(self) -> Blob<BytesBlob> {
+        Blob::new(self)
+    }
+}
+
+impl TryFromBlob<BytesBlob> for Bytes {
+    type Error = Infallible;
+    fn try_from_blob(b: Blob<BytesBlob>) -> Result<Self, Self::Error> {
+        Ok(b.bytes)
+    }
+}
+
+// ending
+
+fn main() {}


### PR DESCRIPTION
## Summary
- document built-in schemas
- link the new chapter in SUMMARY
- provide a compiling example for custom schemas
- note new docs in CHANGELOG
- clarify the schema definition introduction
- list all provided schemas explicitly

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6873d03498008322bcb82b5c1cda721f