### PR TITLE
Document query language with dataset example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build script `build_book.sh` and CI workflow to publish the mdBook.
 - Expanded the introduction and philosophy sections of the Tribles Book and
   documented how to install `mdbook`.
+ - Added a book chapter describing the `find!` query language, listed
+   built-in constraints, and included a reusable sample dataset for
+   documentation examples.
 
 ### Changed
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Introduction](introduction.md)
 - [Getting Started](getting-started.md)
+- [Query Language](query-language.md)
 - Deep Dive
   - [Philosophy](deep-dive/philosophy.md)
   - [Identifiers](deep-dive/identifiers.md)

--- a/book/src/query-language.md
+++ b/book/src/query-language.md
@@ -1,0 +1,69 @@
+# Query Language
+
+This chapter introduces the basic query facilities provided by `tribles`.
+
+The [`find!`](crate::prelude::find) macro builds a [`Query`](crate::query::Query)
+by declaring variables and a constraint expression.  A minimal invocation looks
+like:
+
+```rust
+let results = find!((a), a.is(1.into())).collect::<Vec<_>>();
+```
+
+Variables can optionally specify a concrete type to convert the underlying
+value:
+
+```rust
+find!((x: i32, y: Value<ShortString>),
+      and!(x.is(1.into()), y.is("foo".to_value())))
+```
+
+The first variable is read as an `i32` and the second as a short string if the
+conversion succeeds. The query engine walks all possible assignments that
+satisfy the constraint and yields tuples of the declared variables.
+
+## Built-in constraints
+
+`find!` queries combine a small set of constraint operators to form a declarative
+language for matching tribles:
+
+- [`and!`](crate::prelude::and) builds an
+  [`IntersectionConstraint`](crate::query::intersectionconstraint::IntersectionConstraint)
+  requiring all sub-constraints to hold.
+- [`or!`](crate::prelude::or) constructs a
+  [`UnionConstraint`](crate::query::unionconstraint::UnionConstraint)
+  accepting any satisfied alternative.
+- [`mask!`](crate::prelude::mask) hides variables from a sub-query.
+- Collection types such as [`TribleSet`](crate::tribleset::TribleSet) provide a
+  `has` method yielding a
+  [`ContainsConstraint`](crate::query::hashsetconstraint::ContainsConstraint) for
+  membership tests.
+
+Any data structure that can iterate its contents, test membership and report its
+size can implement `ContainsConstraint`, so queries have no inherent ordering
+requirements.
+
+## Example
+
+```rust
+use tribles::prelude::*;
+use tribles::examples::{self, literature};
+
+let dataset = examples::dataset();
+
+for (title,) in find!((title: Value<_>),
+                     and!(dataset.has(title), title.is("Dune".to_value()))) {
+    println!("Found {}", title.from_value::<&str>());
+}
+```
+
+This query searches the example dataset for the book titled "Dune".  The
+variables and constraint can be adapted to express more complex joins and
+filters.
+
+## Custom constraints
+
+Every building block implements the
+[`Constraint`](crate::query::Constraint) trait.  You can implement this trait on
+your own types to integrate custom data sources or query operators with the
+solver.

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -3,13 +3,14 @@
 
 use crate::prelude::blobschemas::*;
 use crate::prelude::valueschemas::*;
+use crate::prelude::*;
 use crate::NS;
 
 NS! {
     /// The `literature` namespace contains attributes describing authors and their works.
     /// It is used to demonstrate the capabilities of the `tribles` crate.
     /// The namespace is not intended to be used in practice.
-    pub namespace literature {
+pub namespace literature {
         /// The title of a work.
         "A74AA63539354CDA47F387A4C3A8D54C" as title: ShortString;
         /// A quote from a work.
@@ -23,4 +24,29 @@ NS! {
         /// The number of pages in the work.
         "FCCE870BECA333D059D5CD68C43B98F0" as page_count: R256;
     }
+}
+
+/// Returns a small sample dataset used in the documentation.
+pub fn dataset() -> TribleSet {
+    let mut set = TribleSet::new();
+    let mut blobs = MemoryBlobStore::new();
+    let author_id = ufoid();
+
+    set += literature::entity!(&author_id, {
+        firstname: "Frank",
+        lastname: "Herbert",
+    });
+
+    set += literature::entity!({
+        title: "Dune",
+        author: &author_id,
+        quote: blobs
+            .put("Deep in the human unconscious is a pervasive need for a logical universe that makes sense. But the real universe is always one step beyond logic.")
+            .unwrap(),
+        quote: blobs
+            .put("I must not fear. Fear is the mind-killer. Fear is the little-death that brings total obliteration. I will face my fear. I will permit it to pass over me and through me. And when it has gone past I will turn the inner eye to see its path. Where the fear has gone there will be nothing. Only I will remain.")
+            .unwrap(),
+    });
+
+    set
 }


### PR DESCRIPTION
## Summary
- flesh out the Query Language chapter
- include small dataset generator in examples module
- mention new docs in the changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6873cffb3acc832298024c402ff2f27b