### PR TITLE
Implement Error for OpenError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Workspace` now exposes a `put` method for adding blobs, replacing the old
   `add_blob` helper. The method returns the stored blob's handle directly since
   the underlying store cannot fail.
+- `OpenError` now implements `std::error::Error` and provides clearer messages when opening piles.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -368,6 +368,19 @@ pub enum OpenError {
     CorruptPile { valid_length: usize },
 }
 
+impl std::fmt::Display for OpenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OpenError::IoError(err) => write!(f, "IO error: {}", err),
+            OpenError::PileTooLarge => write!(f, "Pile too large"),
+            OpenError::CorruptPile { valid_length } => {
+                write!(f, "Corrupt pile at byte {}", valid_length)
+            }
+        }
+    }
+}
+impl std::error::Error for OpenError {}
+
 impl From<std::io::Error> for OpenError {
     fn from(err: std::io::Error) -> Self {
         Self::IoError(err)


### PR DESCRIPTION
## Summary
- add `Display` and `Error` impls for `OpenError`
- document the change in `CHANGELOG.md`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875981b339483229ae5d84c2fe9dabe