### PR TITLE
Replace Elias-Fano arrays with bit vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.
 - Clarified need for duplicate `bucket_get_slot` check in `table_get_slot`.
+- Replaced Elias--Fano arrays in `SuccinctArchive` with bit vectors for
+  simpler builds and equivalent query performance.
 - `SuccinctArchive` now counts distinct component pairs using bitsets,
   improving query estimation accuracy.
 - Improved `Debug` output for `Query` to show search state and bindings.

--- a/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
+++ b/src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs
@@ -36,35 +36,37 @@ where
     }
 }
 
-fn base_range<U>(universe: &U, a: &EliasFano, value: &RawValue) -> Range<usize>
+fn base_range<U, B>(universe: &U, a: &B, value: &RawValue) -> Range<usize>
 where
     U: Universe,
+    B: Build + Access + Rank + Select + NumBits,
 {
     if let Some(d) = universe.search(value) {
-        let s = a.select(d).unwrap();
-        let e = a.select(d + 1).unwrap();
+        let s = a.select1(d).unwrap() - d;
+        let e = a.select1(d + 1).unwrap() - (d + 1);
         s..e
     } else {
         0..0
     }
 }
 
-fn restrict_range<U, B>(
+fn restrict_range<U, Bv>(
     universe: &U,
-    a: &EliasFano,
-    c: &WaveletMatrix<B>,
+    a: &Bv,
+    c: &WaveletMatrix<Bv>,
     value: &RawValue,
     r: &Range<usize>,
 ) -> Range<usize>
 where
     U: Universe,
-    B: Build + Access + Rank + Select + NumBits,
+    Bv: Build + Access + Rank + Select + NumBits,
 {
     let s = r.start;
     let e = r.end;
     if let Some(d) = universe.search(value) {
-        let s_ = a.select(d).unwrap() + c.rank(s, d).unwrap();
-        let e_ = a.select(d).unwrap() + c.rank(e, d).unwrap();
+        let base = a.select1(d).unwrap() - d;
+        let s_ = base + c.rank(s, d).unwrap();
+        let e_ = base + c.rank(e, d).unwrap();
         s_..e_
     } else {
         0..0


### PR DESCRIPTION
## Summary
- switch `SuccinctArchive` to build bit vectors instead of Elias–Fano arrays
- swap range calculations to use `select1`/`rank1`
- factor out helper to construct prefix bit vectors
- enumerate column domains via `select0` to skip empty IDs

## Testing
- `cargo test --quiet`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687595895d3c8322901bdc94b6701383