### PR TITLE
Rename repo checkout to pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `branch_id_by_name` helper to resolve branch IDs from names. Returns a
   `NameConflict` error when multiple branches share the same name.
 - Documentation and examples for the repository API.
-- Test coverage for `branch_from` and `checkout_with_key`.
+- Test coverage for `branch_from` and `pull_with_key`.
+- `Workspace::checkout` helper to load commit contents.
+- `Workspace::checkout` now accepts commit ranges for convenient history queries.
 - Git-based terminology notes in the repository guide and a clearer workspace example.
 - Expanded the repository example to store actual data and simplified the conflict loop.
 - Repository workflows chapter covering branching, merging, CLI usage and an improved push/merge diagram.
@@ -54,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Split branch lookup tests into independent cases for better readability.
+- `Repository::checkout` was renamed to `pull` for symmetry with `push`.
+- `IntoCheckoutRange` trait became `CommitSelector` and its `into_vec` method
+  was renamed to `select`.
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.
 - Clarified need for duplicate `bucket_get_slot` check in `table_get_slot`.
 - Replaced Elias--Fano arrays in `SuccinctArchive` with bit vectors for

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -51,7 +51,7 @@ A [`Workspace`](https://docs.rs/tribles/latest/tribles/repo/struct.Workspace.htm
 |   |      BlobStore      |   |        BranchStore        | |
 |   +---------------------+   +----------------------------+ |
 +-----------------------------------------------------------+
-           ^ checkout                            | push
+           ^ pull                                | push
            |                                     v
 +-----------------------------------------------------------+
 |                        Workspace                           |

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -13,12 +13,12 @@ familiar to anyone comfortable with Git.
 A branch records a line of history. Creating one writes initial metadata to the
 underlying store and yields a `Workspace` pointing at that branch. While
 `Repository::branch` is a convenient way to start a fresh branch, most workflows
-use `Repository::checkout` to obtain a workspace for an existing branch:
+use `Repository::pull` to obtain a workspace for an existing branch:
 
 ```rust
 let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
 let mut ws = repo.branch("main").expect("create branch");
-let mut ws2 = repo.checkout(ws.branch_id()).expect("open branch");
+let mut ws2 = repo.pull(ws.branch_id()).expect("open branch");
 ```
 
 After committing changes you can push the workspace back:
@@ -26,6 +26,14 @@ After committing changes you can push the workspace back:
 ```rust
 ws.commit(change, Some("initial commit"));
 repo.push(&mut ws)?;
+```
+
+You can inspect previous commits using `Workspace::checkout` which returns a
+`TribleSet` with the union of the specified commit contents. Commit ranges
+are supported for convenience:
+
+```rust
+let history = ws.checkout(commit_a..=commit_b)?;
 ```
 
 ## Merging and Conflict Handling

--- a/examples/repo.rs
+++ b/examples/repo.rs
@@ -25,7 +25,7 @@ fn main() {
     repo.push(&mut ws1).expect("push ws1");
 
     // Second workspace adds Bob and attempts to push, merging on conflict
-    let mut ws2 = repo.checkout(branch_id).expect("checkout");
+    let mut ws2 = repo.pull(branch_id).expect("pull");
     let mut change = TribleSet::new();
     change += literature::entity!(&ufoid(), { firstname: "Bob" });
     ws2.commit(change, Some("add bob"));

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -55,7 +55,7 @@
 //! }
 //! ```
 //!
-//! `checkout` creates a new workspace from an existing branch while
+//! `pull` creates a new workspace from an existing branch while
 //! `branch_from` can be used to start a new branch from a specific commit
 //! handle. See `examples/workspace.rs` for a more complete example.
 //!
@@ -89,9 +89,9 @@
 //! - `push` updates the repository atomically. If the branch advanced in the
 //!   meantime, you receive a conflict workspace which can be merged before
 //!   retrying the push.
-//! - `checkout` is similar to cloning a branch into a new workspace.
+//! - `pull` is similar to cloning a branch into a new workspace.
 //!
-//! `checkout` uses the repository's default signing key for new commits. If you
+//! `pull` uses the repository's default signing key for new commits. If you
 //! need to work with a different identity, the `_with_key` variants allow providing
 //! an explicit key when branching or checking out.
 //!
@@ -440,7 +440,7 @@ pub struct Repository<Storage: BlobStore<Blake3> + BranchStore<Blake3>> {
     signing_key: SigningKey,
 }
 
-pub enum CheckoutError<BranchStorageErr, BlobStorageErr>
+pub enum PullError<BranchStorageErr, BlobStorageErr>
 where
     BranchStorageErr: Error,
     BlobStorageErr: Error,
@@ -455,17 +455,17 @@ where
     BadBranchMetadata(),
 }
 
-impl<B, C> fmt::Debug for CheckoutError<B, C>
+impl<B, C> fmt::Debug for PullError<B, C>
 where
     B: Error + fmt::Debug,
     C: Error + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CheckoutError::BranchNotFound(id) => f.debug_tuple("BranchNotFound").field(id).finish(),
-            CheckoutError::BranchStorage(e) => f.debug_tuple("BranchStorage").field(e).finish(),
-            CheckoutError::BlobStorage(e) => f.debug_tuple("BlobStorage").field(e).finish(),
-            CheckoutError::BadBranchMetadata() => f.debug_tuple("BadBranchMetadata").finish(),
+            PullError::BranchNotFound(id) => f.debug_tuple("BranchNotFound").field(id).finish(),
+            PullError::BranchStorage(e) => f.debug_tuple("BranchStorage").field(e).finish(),
+            PullError::BlobStorage(e) => f.debug_tuple("BlobStorage").field(e).finish(),
+            PullError::BadBranchMetadata() => f.debug_tuple("BadBranchMetadata").finish(),
         }
     }
 }
@@ -603,28 +603,28 @@ where
         }
     }
 
-    /// Checks out an existing branch using the repository's signing key.
-    pub fn checkout(
+    /// Pulls an existing branch using the repository's signing key.
+    pub fn pull(
         &mut self,
         branch_id: Id,
     ) -> Result<
         Workspace<Storage>,
-        CheckoutError<
+        PullError<
             Storage::HeadError,
             <Storage::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>,
         >,
     > {
-        self.checkout_with_key(branch_id, self.signing_key.clone())
+        self.pull_with_key(branch_id, self.signing_key.clone())
     }
 
-    /// Same as [`checkout`] but overrides the signing key.
-    pub fn checkout_with_key(
+    /// Same as [`pull`] but overrides the signing key.
+    pub fn pull_with_key(
         &mut self,
         branch_id: Id,
         signing_key: SigningKey,
     ) -> Result<
         Workspace<Storage>,
-        CheckoutError<
+        PullError<
             Storage::HeadError,
             <Storage::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>,
         >,
@@ -632,13 +632,13 @@ where
         // 1. Get the branch metadata head from the branch store.
         let base_branch_meta_handle = match self.storage.head(branch_id) {
             Ok(Some(handle)) => handle,
-            Ok(None) => return Err(CheckoutError::BranchNotFound(branch_id)),
-            Err(e) => return Err(CheckoutError::BranchStorage(e)),
+            Ok(None) => return Err(PullError::BranchNotFound(branch_id)),
+            Err(e) => return Err(PullError::BranchStorage(e)),
         };
         // 2. Get the current commit from the branch metadata.
         let base_branch_meta: TribleSet = match self.storage.reader().get(base_branch_meta_handle) {
             Ok(metadata) => metadata,
-            Err(e) => return Err(CheckoutError::BlobStorage(e)),
+            Err(e) => return Err(PullError::BlobStorage(e)),
         };
 
         let head = match find!(
@@ -649,7 +649,7 @@ where
         {
             Ok(Some((h,))) => Some(h),
             Ok(None) => None,
-            Err(_) => return Err(CheckoutError::BadBranchMetadata()),
+            Err(_) => return Err(PullError::BadBranchMetadata()),
         };
         // Create workspace with the current commit and base blobs.
         Ok(Workspace {
@@ -834,10 +834,162 @@ where
     }
 }
 
+/// Helper trait for [`Workspace::checkout`] specifying commit handles or ranges.
+pub trait CommitSelector<Blobs: BlobStore<Blake3>> {
+    fn select(
+        self,
+        ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    >;
+}
+
+impl<Blobs> CommitSelector<Blobs> for CommitHandle
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        _ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        Ok(vec![self])
+    }
+}
+
+impl<Blobs> CommitSelector<Blobs> for Vec<CommitHandle>
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        _ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        Ok(self)
+    }
+}
+
+impl<'a, Blobs> CommitSelector<Blobs> for &'a [CommitHandle]
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        _ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        Ok(self.to_vec())
+    }
+}
+
+impl<Blobs> CommitSelector<Blobs> for std::ops::Range<CommitHandle>
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        ws.collect_range(Some(self.start), Some(self.end), false)
+    }
+}
+
+impl<Blobs> CommitSelector<Blobs> for std::ops::RangeInclusive<CommitHandle>
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        let (start, end) = self.into_inner();
+        ws.collect_range(Some(start), Some(end), true)
+    }
+}
+
+impl<Blobs> CommitSelector<Blobs> for std::ops::RangeFrom<CommitHandle>
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        ws.collect_range(Some(self.start), None, true)
+    }
+}
+
+impl<Blobs> CommitSelector<Blobs> for std::ops::RangeTo<CommitHandle>
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        ws.collect_range(None, Some(self.end), false)
+    }
+}
+
+impl<Blobs> CommitSelector<Blobs> for std::ops::RangeToInclusive<CommitHandle>
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        ws.collect_range(None, Some(self.end), true)
+    }
+}
+
+impl<Blobs> CommitSelector<Blobs> for std::ops::RangeFull
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        ws.collect_range(None, None, true)
+    }
+}
+
 impl<Blobs: BlobStore<Blake3>> Workspace<Blobs> {
     /// Returns the branch id associated with this workspace.
     pub fn branch_id(&self) -> Id {
         self.base_branch_id
+    }
+
+    /// Returns the current commit handle if one exists.
+    pub fn head(&self) -> Option<CommitHandle> {
+        self.head
     }
 
     /// Adds a blob to the workspace's local blob store.
@@ -914,4 +1066,140 @@ impl<Blobs: BlobStore<Blake3>> Workspace<Blobs> {
 
         Ok(commit_handle)
     }
+
+    fn first_parent(
+        &mut self,
+        commit: CommitHandle,
+    ) -> Result<
+        Option<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        let meta: TribleSet = self
+            .local_blobs
+            .reader()
+            .get(commit)
+            .or_else(|_| self.base_blobs.get(commit))
+            .map_err(WorkspaceCheckoutError::Storage)?;
+
+        match find!( (p: Value<_>), repo::pattern!(&meta, [{ parent: p }]) ).at_most_one() {
+            Ok(Some((p,))) => Ok(Some(p)),
+            Ok(None) => Ok(None),
+            Err(_) => Err(WorkspaceCheckoutError::BadCommitMetadata()),
+        }
+    }
+
+    fn collect_range(
+        &mut self,
+        start: Option<CommitHandle>,
+        end: Option<CommitHandle>,
+        inclusive_end: bool,
+    ) -> Result<
+        Vec<CommitHandle>,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        let mut result = Vec::new();
+        let mut current = match end.or(self.head) {
+            Some(c) => c,
+            None => return Err(WorkspaceCheckoutError::NoHead),
+        };
+
+        loop {
+            result.push(current);
+            if Some(current) == start {
+                break;
+            }
+            match self.first_parent(current)? {
+                Some(p) => current = p,
+                None => break,
+            }
+        }
+        result.reverse();
+        if !inclusive_end {
+            result.pop();
+        }
+        Ok(result)
+    }
+
+    /// Returns the combined [`TribleSet`] for the specified commits.
+    ///
+    /// Each commit handle must reference a commit blob stored either in the
+    /// workspace's local blob store or the repository's base store. The
+    /// associated content blobs are loaded and unioned together. An error is
+    /// returned if any commit or content blob is missing or malformed.
+    fn checkout_commits<I>(
+        &mut self,
+        commits: I,
+    ) -> Result<
+        TribleSet,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    >
+    where
+        I: IntoIterator<Item = CommitHandle>,
+    {
+        let local = self.local_blobs.reader();
+        let mut result = TribleSet::new();
+        for commit in commits {
+            let meta: TribleSet = local
+                .get(commit)
+                .or_else(|_| self.base_blobs.get(commit))
+                .map_err(WorkspaceCheckoutError::Storage)?;
+
+            let Ok((content,)) = find!(
+                (c: Value<_>),
+                repo::pattern!(&meta, [{ content: c }])
+            )
+            .exactly_one() else {
+                return Err(WorkspaceCheckoutError::BadCommitMetadata());
+            };
+
+            let set: TribleSet = local
+                .get(content)
+                .or_else(|_| self.base_blobs.get(content))
+                .map_err(WorkspaceCheckoutError::Storage)?;
+
+            result.union(set);
+        }
+        Ok(result)
+    }
+
+    /// Returns the combined [`TribleSet`] for the specified commits or commit
+    /// ranges. `spec` can be a single [`CommitHandle`], an iterator of handles
+    /// or any of the standard range types over `CommitHandle`.
+    pub fn checkout<R>(
+        &mut self,
+        spec: R,
+    ) -> Result<
+        TribleSet,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    >
+    where
+        R: CommitSelector<Blobs>,
+    {
+        let commits = spec.select(self)?;
+        self.checkout_commits(commits)
+    }
 }
+
+#[derive(Debug)]
+pub enum WorkspaceCheckoutError<GetErr: Error> {
+    /// Error retrieving blobs from storage.
+    Storage(GetErr),
+    /// Commit metadata is malformed or missing required fields.
+    BadCommitMetadata(),
+    /// The workspace has no commits yet.
+    NoHead,
+}
+
+impl<E: Error + fmt::Debug> fmt::Display for WorkspaceCheckoutError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WorkspaceCheckoutError::Storage(e) => write!(f, "storage error: {}", e),
+            WorkspaceCheckoutError::BadCommitMetadata() => {
+                write!(f, "commit metadata missing content field")
+            }
+            WorkspaceCheckoutError::NoHead => write!(f, "workspace has no commits"),
+        }
+    }
+}
+
+impl<E: Error + fmt::Debug> Error for WorkspaceCheckoutError<E> {}

--- a/src/repo/objectstore.rs
+++ b/src/repo/objectstore.rs
@@ -390,8 +390,8 @@ pub enum PullBranchErr {
 impl fmt::Display for PullBranchErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::StoreErr(e) => write!(f, "checkout failed: {}", e),
-            Self::ValidationErr(e) => write!(f, "checkout failed: {}", e),
+            Self::StoreErr(e) => write!(f, "pull failed: {}", e),
+            Self::ValidationErr(e) => write!(f, "pull failed: {}", e),
         }
     }
 }

--- a/tests/branch.rs
+++ b/tests/branch.rs
@@ -9,8 +9,8 @@ fn repository_branch_creates_branch() {
     let ws = repo.branch("main").expect("create branch");
     let branch_id = ws.branch_id();
 
-    match repo.checkout(branch_id) {
+    match repo.pull(branch_id) {
         Ok(_) => {}
-        Err(_) => panic!("checkout failed"),
+        Err(_) => panic!("pull failed"),
     }
 }

--- a/tests/objectstore_repo.rs
+++ b/tests/objectstore_repo.rs
@@ -13,7 +13,7 @@ fn objectstore_branch_creates_branch() {
     let ws = repo.branch("main").expect("create branch");
     let branch_id = ws.branch_id();
 
-    repo.checkout(branch_id).expect("checkout");
+    repo.pull(branch_id).expect("pull");
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn objectstore_workspace_commit_updates_head() {
 }
 
 #[test]
-fn objectstore_branch_from_and_checkout_with_key() {
+fn objectstore_branch_from_and_pull_with_key() {
     let url = Url::parse("memory:///repo3").unwrap();
     let mut store = ObjectStoreRemote::<Blake3>::with_url(&url).unwrap();
     let key = SigningKey::generate(&mut OsRng);
@@ -46,8 +46,7 @@ fn objectstore_branch_from_and_checkout_with_key() {
 
     let other_key = SigningKey::generate(&mut OsRng);
     let branch_id = ws.branch_id();
-    repo.checkout_with_key(branch_id, other_key)
-        .expect("checkout");
+    repo.pull_with_key(branch_id, other_key).expect("pull");
 }
 
 #[test]
@@ -57,7 +56,7 @@ fn objectstore_push_and_merge_conflict_resolution() {
     let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
     let mut ws1 = repo.branch("main").expect("create branch");
     let branch_id = ws1.branch_id();
-    let mut ws2 = repo.checkout(branch_id).expect("checkout");
+    let mut ws2 = repo.pull(branch_id).expect("pull");
 
     ws1.commit(TribleSet::new(), Some("first"));
     ws2.commit(TribleSet::new(), Some("second"));

--- a/tests/push_merge.rs
+++ b/tests/push_merge.rs
@@ -9,7 +9,7 @@ fn push_and_merge_conflict_resolution() {
     let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
     let mut ws1 = repo.branch("main").expect("create branch");
     let branch_id = ws1.branch_id();
-    let mut ws2 = repo.checkout(branch_id).expect("checkout");
+    let mut ws2 = repo.pull(branch_id).expect("pull");
 
     ws1.commit(TribleSet::new(), Some("first"));
     ws2.commit(TribleSet::new(), Some("second"));

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -4,7 +4,7 @@ use tribles::prelude::*;
 use tribles::repo::{commit, memoryrepo::MemoryRepo, LookupError, Repository};
 
 #[test]
-fn branch_from_and_checkout_with_key() {
+fn branch_from_and_pull_with_key() {
     // prepare storage with an initial commit
     let mut store = MemoryRepo::default();
     let key = SigningKey::generate(&mut OsRng);
@@ -16,11 +16,10 @@ fn branch_from_and_checkout_with_key() {
     ws.commit(TribleSet::new(), Some("work"));
     repo.push(&mut ws).expect("push");
 
-    // checkout using a different key should succeed
+    // pull using a different key should succeed
     let other_key = SigningKey::generate(&mut OsRng);
     let branch_id = ws.branch_id();
-    repo.checkout_with_key(branch_id, other_key)
-        .expect("checkout");
+    repo.pull_with_key(branch_id, other_key).expect("pull");
 }
 
 #[test]

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -16,3 +16,133 @@ fn workspace_commit_updates_head() {
         Ok(_) | Err(_) => panic!("push failed"),
     }
 }
+
+#[test]
+fn workspace_checkout_unions_commits() {
+    use tribles::value::schemas::r256::R256;
+
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+    let mut ws = repo.branch("main").expect("create branch");
+
+    let e1 = ufoid();
+    let a1 = ufoid();
+    let v1: Value<R256> = 1i128.to_value();
+    let t1 = Trible::new(&e1, &a1, &v1);
+    let mut s1 = TribleSet::new();
+    s1.insert(&t1);
+
+    ws.commit(s1.clone(), None);
+    let c1 = ws.head().unwrap();
+
+    let e2 = ufoid();
+    let a2 = ufoid();
+    let v2: Value<R256> = 2i128.to_value();
+    let t2 = Trible::new(&e2, &a2, &v2);
+    let mut s2 = TribleSet::new();
+    s2.insert(&t2);
+
+    ws.commit(s2.clone(), None);
+    let c2 = ws.head().unwrap();
+
+    let result = ws.checkout(&[c1, c2][..]).expect("checkout");
+
+    let mut expected = s1;
+    expected.union(s2);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn workspace_checkout_single_commit() {
+    use tribles::value::schemas::r256::R256;
+
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+    let mut ws = repo.branch("main").expect("create branch");
+
+    let e = ufoid();
+    let a = ufoid();
+    let v: Value<R256> = 42i128.to_value();
+    let t = Trible::new(&e, &a, &v);
+    let mut s = TribleSet::new();
+    s.insert(&t);
+
+    ws.commit(s.clone(), None);
+    let c = ws.head().unwrap();
+
+    let result = ws.checkout(c).expect("checkout single");
+
+    assert_eq!(result, s);
+}
+
+#[test]
+fn workspace_checkout_vec_commits() {
+    use tribles::value::schemas::r256::R256;
+
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+    let mut ws = repo.branch("main").expect("create branch");
+
+    let mut sets = Vec::new();
+    let mut commits = Vec::new();
+    for i in 0..3i128 {
+        let e = ufoid();
+        let a = ufoid();
+        let v: Value<R256> = i.to_value();
+        let t = Trible::new(&e, &a, &v);
+        let mut s = TribleSet::new();
+        s.insert(&t);
+        ws.commit(s.clone(), None);
+        sets.push(s);
+        commits.push(ws.head().unwrap());
+    }
+
+    let result = ws.checkout(commits.clone()).expect("checkout vec");
+
+    let mut expected = TribleSet::new();
+    for s in sets {
+        expected.union(s);
+    }
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn workspace_checkout_range_variants() {
+    use tribles::value::schemas::r256::R256;
+
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+    let mut ws = repo.branch("main").expect("create branch");
+
+    let mut sets = Vec::new();
+    let mut handles = Vec::new();
+    for i in 0..3i128 {
+        let e = ufoid();
+        let a = ufoid();
+        let v: Value<R256> = i.to_value();
+        let t = Trible::new(&e, &a, &v);
+        let mut s = TribleSet::new();
+        s.insert(&t);
+        ws.commit(s.clone(), None);
+        sets.push(s);
+        handles.push(ws.head().unwrap());
+    }
+
+    let (c1, c2, c3) = (handles[0], handles[1], handles[2]);
+
+    let mut s1s2 = sets[0].clone();
+    s1s2.union(sets[1].clone());
+    let mut s2s3 = sets[1].clone();
+    s2s3.union(sets[2].clone());
+    let mut s1s2s3 = s1s2.clone();
+    s1s2s3.union(sets[2].clone());
+
+    assert_eq!(ws.checkout(c1..c3).unwrap(), s1s2.clone());
+    assert_eq!(ws.checkout(c1..=c3).unwrap(), s1s2s3.clone());
+    assert_eq!(ws.checkout(c2..).unwrap(), s2s3.clone());
+    assert_eq!(ws.checkout(..c3).unwrap(), s1s2.clone());
+    assert_eq!(ws.checkout(..=c2).unwrap(), s1s2.clone());
+    assert_eq!(ws.checkout(..).unwrap(), s1s2s3);
+}


### PR DESCRIPTION
## Summary
- rename `Repository::checkout` to `pull`
- introduce `Workspace::checkout` with range support
- rename checkout helper trait to `CommitSelector`
- document commit range queries and update changelog
- add tests covering all checkout styles

## Testing
- `cargo test --quiet`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687846c6a68c8322a1187abdd1d74d54