### PR TITLE
Add namespace generation TODOs and drop delta attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immutable.
 - Documented the incremental query plan in `INVENTORY.md` and linked it
   to a new "Incremental Queries" book chapter detailing the approach.
-- Noted that namespaces will expose a `delta!` operator, similar to
-  `pattern!`, for expressing changes between `TribleSet`s. The macro
-  computes the difference and uses `union!` internally to apply the
-  delta constraint.
+- Noted plans for a `delta!` operator to assist with incremental
+  queries. Documentation describes how it will union patterns with
+  each triple constrained to the dataset delta.
+- Recorded a future task to generate namespaces from a TribleSet
+  description and to rewrite `pattern!` as a procedural macro.
+- Documented the internal `pattern_inner!` macro with expanded usage notes.
+- Added inline comments for every `pattern_inner!` rule describing what it
+  matches and why.
 
 ### Changed
+- Removed the experimental `delta!` macro implementation; incremental
+  query support will be revisited once `pattern!` becomes a procedural
+  macro.
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.
 - Clarified need for duplicate `bucket_get_slot` check in `table_get_slot`.
 - Replaced Elias--Fano arrays in `SuccinctArchive` with bit vectors for

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -16,6 +16,9 @@
   internally and matches only the newly added tribles. See the book's
   [Incremental Queries](book/src/incremental-queries.md) chapter for
   the planned approach.
+- Generate namespaces from a `TribleSet` description so tooling can
+  derive them programmatically. Rewriting `pattern!` as a procedural
+  macro will be the first step toward this automation.
 
 ## Discovered Issues
 - No open issues recorded yet.


### PR DESCRIPTION
## Summary
- remove the experimental `delta!` macro
- drop the incremental example using it
- keep documentation clarifying `pattern_inner!`
- note plans for auto-generated namespaces and a procedural `pattern!` in `INVENTORY.md`
- record removal and future plans in the changelog

## Testing
- `cargo test --quiet`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6876e16aefa8832284c227ec9ac231fb