### PR TITLE
Update README links and inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `INVENTORY.md` file and instructions for recording future work.
+- README now links to the corresponding chapters on https://triblespace.github.io/tribles-rust.
 - `branch_id_by_name` helper to resolve branch IDs from names. Returns a
   `NameConflict` error when multiple branches share the same name.
 - Documentation and examples for the repository API.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -28,5 +28,15 @@
   derive them programmatically. Rewriting `pattern!` as a procedural
   macro will be the first step toward this automation.
 
+## Documentation
+- Move the "Portability & Common Formats" overview from `src/value.rs` into a
+  dedicated chapter of the book.
+- Migrate the blob module introduction in `src/blob.rs` so the crate docs focus
+  on API details.
+- Extract the repository design discussion and Git parallels from `src/repo.rs`
+  into the book.
+- Split out the lengthy explanation of trible structure from `src/trible.rs`
+  and consolidate it with the deep dive chapter.
+
 ## Discovered Issues
 - No open issues recorded yet.

--- a/README.md
+++ b/README.md
@@ -146,20 +146,20 @@ For details on setting up a development environment, see [Developing Locally](bo
 
 # Learn More
 
-The best way to get started is to read the module documentation of the `tribles` crate. The following links provide an overview of the most important modules, in an order where you can start with the most basic concepts and work your way up to more advanced topics:
+The best way to get started is to read the [Tribles Book](https://triblespace.github.io/tribles-rust/). The following links mirror the book's chapter order so you can progress from the basics to more advanced topics:
 
-1. [Prelude](https://docs.rs/tribles/latest/tribles/prelude/index.html)
-2. [Identifiers](https://docs.rs/tribles/latest/tribles/id/index.html)
-3. [Values](https://docs.rs/tribles/latest/tribles/value/index.html)
-4. [Blobs](https://docs.rs/tribles/latest/tribles/blob/index.html)
-5. [Tribles](https://docs.rs/tribles/latest/tribles/trible/index.html)
-6. [Namespaces](https://docs.rs/tribles/latest/tribles/namespace/index.html)
-7. [Queries](https://docs.rs/tribles/latest/tribles/query/index.html)
-8. [Remotes](https://docs.rs/tribles/latest/tribles/remote/index.html)
-9. [Predefined Value Schemas](https://docs.rs/tribles/latest/tribles/value/schemas/index.html)
-10. [Predefined Blob Schemas](https://docs.rs/tribles/latest/tribles/blob/schemas/index.html)
-11. [Pile format and recovery](https://docs.rs/tribles/latest/tribles/repo/struct.Pile.html)
-12. [Repository and Workspace](https://docs.rs/tribles/latest/tribles/repo/index.html)
+1. [Introduction](https://triblespace.github.io/tribles-rust/introduction.html)
+2. [Getting Started](https://triblespace.github.io/tribles-rust/getting-started.html)
+3. [Architecture](https://triblespace.github.io/tribles-rust/architecture.html)
+4. [Query Language](https://triblespace.github.io/tribles-rust/query-language.html)
+5. [Incremental Queries](https://triblespace.github.io/tribles-rust/incremental-queries.html)
+6. [Schemas](https://triblespace.github.io/tribles-rust/schemas.html)
+7. [Repository Workflows](https://triblespace.github.io/tribles-rust/repository-workflows.html)
+8. [Commit Selectors](https://triblespace.github.io/tribles-rust/commit-selectors.html)
+9. [Philosophy](https://triblespace.github.io/tribles-rust/deep-dive/philosophy.html)
+10. [Identifiers](https://triblespace.github.io/tribles-rust/deep-dive/identifiers.html)
+11. [Trible Structure](https://triblespace.github.io/tribles-rust/deep-dive/trible-structure.html)
+12. [Pile Format](https://triblespace.github.io/tribles-rust/pile-format.html)
 ## License
 
 Licensed under either of


### PR DESCRIPTION
## Summary
- point README's Learn More section at the Tribles Book chapters
- document README change in the changelog
- track tasks to move lengthy crate docs into the book in `INVENTORY.md`

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ece8a30108322b1cf0fb4c816321b