### PR TITLE
reuse attribute vars in pattern macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced branch allocation code with `Layout::from_size_align_unchecked`.
 - Removed unused `FromBlob` and `TryToBlob` traits and updated documentation.
 - Simplified constant comparison in query tests.
+- `pattern!` now reuses attribute variables for identical field names.
 - Clarified that the project's developer experience goal also includes
   providing an intuitive API for library users.
 - Documented Kani proof guidelines to avoid constants and prefer


### PR DESCRIPTION
## Summary
- generate attribute variables only once when expanding `pattern!`
- rename the entity index variable for clarity
- update CHANGELOG

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fad44e68c83228e1359ba45ac67f9