### PR TITLE
Return PATCH from commit selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   starting point.
 - Scalar commit selectors once again return only the specified commit.
 - Introduced an `ancestors` selector to retrieve a commit and its history.
+- Commit selectors now return a `CommitSet` patch of commit handles instead of a `Vec`.
+- Renamed the `CommitPatch` type alias to `CommitSet`.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/book/src/commit-selectors.md
+++ b/book/src/commit-selectors.md
@@ -10,8 +10,8 @@ Instead of passing ranges, callers would construct *commit sets* derived from
 reachability.  Primitive functions like `ancestors(<commit>)` and
 `descendants(<commit>)` would produce sets.  Higher level combinators such as
 `union`, `intersection` and `difference` would then let users express queries
-like "A minus B" or "ancestors of A intersect B".  The result of a selector
-would still be an ordered list of commits for `checkout` to load.
+like "A minus B" or "ancestors of A intersect B".  Each selector would return
+a `CommitSet` patch of commit handles for `checkout` to load.
 
 This approach aligns with Git's mental model and keeps selection logic separate
 from workspace mutation.  It also opens the door for additional operations on


### PR DESCRIPTION
## Summary
- return `CommitSet` from `CommitSelector::select`
- gather ranges and reachable commits into sets
- update `checkout` to use sets
- document change in commit selectors design note
- log rename of `CommitPatch` to `CommitSet` in `CHANGELOG`

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fb1d377a48322b37f470d82d68950