### PR TITLE
Improve two-dot commit range semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced an `ancestors` selector to retrieve a commit and its history.
 - Commit selectors now return a `CommitSet` patch of commit handles instead of a `Vec`.
 - Renamed the `CommitPatch` type alias to `CommitSet`.
+- The `..` commit selector now computes `reachable(end) minus reachable(start)`
+  via set operations, matching Git's two-dot semantics even across merges.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -938,10 +938,9 @@ where
         CommitSet,
         WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
     > {
-        let mut patch = collect_range(ws, Some(self.start), Some(self.end), true)?;
-        // Exclude the starting commit to mirror git semantics
-        patch.remove(&self.start.raw);
-        Ok(patch)
+        let patch = collect_reachable(ws, self.end)?;
+        let exclude = collect_reachable(ws, self.start)?;
+        Ok(patch.difference(&exclude))
     }
 }
 


### PR DESCRIPTION
## Summary
- implement git-style two-dot range selector using `CommitSet` difference
- document updated semantics in `CHANGELOG.md`

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fd2011280832295935560e6c1283d