### PR TITLE
Port entity_inner macro to procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test coverage for `branch_from` and `pull_with_key`.
 - `Workspace::checkout` helper to load commit contents.
 - `pattern!` now implemented as a procedural macro in the new `tribles-macros` crate.
+- `entity!` now implemented as a procedural macro alongside `pattern!`.
+- `entity!` subsumes the old `entity_inner!` helper; macro invocations can
+  optionally provide an existing `TribleSet`.
 - Expanded documentation for the `pattern` procedural macro to ease maintenance, including detailed comments inside the implementation.
 - `EntityId` variants renamed to `Var` and `Lit` for consistency with field patterns.
 - `Workspace::checkout` now accepts commit ranges for convenient history queries.

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -15,22 +15,6 @@
 /// Hidden by default, used internally by the `entity!` macro.
 pub use hex_literal;
 
-#[doc(hidden)]
-#[macro_export]
-macro_rules! entity_inner {
-    ($Namespace:path, $Set:expr, $EntityId:expr, {$($FieldName:ident : $Value:expr),* $(,)?}) => {
-        {
-            use $Namespace as ns;
-            $(
-                { let v: $crate::value::Value<ns::schemas::$FieldName> = $crate::value::ToValue::to_value($Value);
-                $Set.insert(&$crate::trible::Trible::new($EntityId, &ns::ids::$FieldName, &v)); }
-            )*
-        }
-    };
-}
-
-pub use entity_inner;
-
 /// Defines a Rust module to represent a namespace, along with convenience macros.
 /// The `namespace` block maps human-readable names to attribute IDs and type schemas.
 #[macro_export]
@@ -72,20 +56,12 @@ macro_rules! NS {
             macro_rules! entity {
                 ($entity:tt) => {
                     {
-                        use $crate::namespace::entity_inner;
-                        let mut set = $crate::trible::TribleSet::new();
-                        let id: $crate::id::ExclusiveId = $crate::id::rngid();
-                        entity_inner!($mod_name, &mut set, &id, $entity);
-                        set
+                        ::tribles_macros::entity!(::tribles, $mod_name, $entity)
                     }
                 };
                 ($entity_id:expr, $entity:tt) => {
                     {
-                        use $crate::namespace::entity_inner;
-                        let mut set = $crate::trible::TribleSet::new();
-                        let id: &$crate::id::ExclusiveId = $entity_id;
-                        entity_inner!($mod_name, &mut set, id, $entity);
-                        set
+                        ::tribles_macros::entity!(::tribles, $mod_name, $entity_id, $entity)
                     }
                 };
             }


### PR DESCRIPTION
## Summary
- move `entity_inner` macro from namespace module into procedural macros crate
- call the new procedural macro from `entity!`
- update documentation to reference all three procedural macros
- add changelog entry for `entity_inner!`

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fe228fa9483228b1b61c0e9fc9ecd