### PR TITLE
Implement symmetric diff commit selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed the `CommitPatch` type alias to `CommitSet`.
 - The `..` commit selector now computes `reachable(end) minus reachable(start)`
   via set operations, matching Git's two-dot semantics even across merges.
+- Added a `symmetric_diff` selector corresponding to Git's `A...B` three-dot
+  syntax.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/book/src/commit-selectors.md
+++ b/book/src/commit-selectors.md
@@ -38,8 +38,8 @@ than commits are listed for completeness but are unlikely to be implemented.
 | `:/text` | `search_repo(text)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-textegfixnastybug) | Not planned: requires repository search |
 | `A:path` | `blob_at(A, path)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revpathegHEADREADMEmasterREADME) | Not planned: selects a blob not a commit |
 | `:[N:]path` | `index_blob(path, N)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-npatheg0READMEREADME) | Not planned: selects from the index |
-| `A..B` | `range(A, B)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-Thetwo-dotRangeNotation) | Unimplemented |
-| `A...B` | `symmetric_diff(A, B)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-Thethree-dotSymmetricDifferenceNotation) | Unimplemented |
+| `A..B` | `range(A, B)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-Thetwo-dotRangeNotation) | Implemented |
+| `A...B` | `symmetric_diff(A, B)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-Thethree-dotSymmetricDifferenceNotation) | Implemented |
 | `^A` | `exclude(reachable(A))` | [gitrevisions](https://git-scm.com/docs/gitrevisions#_commit_exclusions) | Unimplemented |
 | `A@{upstream}` | `upstream_of(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-branchnameupstreamegmasterupstreamu) | Not planned: depends on remote config |
 | `A@{push}` | `push_target_of(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-branchnamepushegmasterpushpush) | Not planned: depends on remote config |

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,7 +1,7 @@
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{ancestors, memoryrepo::MemoryRepo, Repository};
+use tribles::repo::{ancestors, memoryrepo::MemoryRepo, symmetric_diff, Repository};
 
 #[test]
 fn workspace_commit_updates_head() {
@@ -143,6 +143,35 @@ fn workspace_checkout_range_variants() {
     assert_eq!(ws.checkout(c2..).unwrap(), s2s3.clone());
     assert_eq!(ws.checkout(..c3).unwrap(), s1s2.clone());
     assert_eq!(ws.checkout(..).unwrap(), s1s2s3);
+}
+
+#[test]
+fn workspace_checkout_symmetric_diff() {
+    use tribles::value::schemas::r256::R256;
+
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+    let mut ws = repo.branch("main").expect("create branch");
+
+    let mut sets = Vec::new();
+    let mut handles = Vec::new();
+    for i in 0..3i128 {
+        let e = ufoid();
+        let a = ufoid();
+        let v: Value<R256> = i.to_value();
+        let t = Trible::new(&e, &a, &v);
+        let mut s = TribleSet::new();
+        s.insert(&t);
+        ws.commit(s.clone(), None);
+        sets.push(s);
+        handles.push(ws.head().unwrap());
+    }
+
+    let (c1, _c2, c3) = (handles[0], handles[1], handles[2]);
+    let mut expected = sets[1].clone();
+    expected.union(sets[2].clone());
+
+    assert_eq!(ws.checkout(symmetric_diff(c1, c3)).unwrap(), expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- support `symmetric_diff` selector for `A...B` commit syntax
- document implemented two- and three-dot ranges
- test symmetric difference checkout

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68803ae6d0888322a3320ee27bc8fb40