### PR TITLE
Implement procedural delta macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `entity!` now implemented as a procedural macro alongside `pattern!`.
 - `entity!` subsumes the old `entity_inner!` helper; macro invocations can
   optionally provide an existing `TribleSet`.
+- Implemented a procedural `delta!` macro for incremental query support.
 - Expanded documentation for the `pattern` procedural macro to ease maintenance, including detailed comments inside the implementation.
 - `EntityId` variants renamed to `Var` and `Lit` for consistency with field patterns.
 - `Workspace::checkout` now accepts commit ranges for convenient history queries.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -4,18 +4,13 @@
 - None at the moment.
 
 ## Completed Work
-- None yet. This file now tracks development ideas.
+- Implemented a `delta!` macro for incremental queries. The macro
+  computes the difference between two `TribleSet`s and unions per-triple
+  results so callers only see newly inserted data.
 
 ## Desired Functionality
 - Finalize the compressed zero-copy archive format currently mentioned as WIP.
 - Provide additional examples showcasing advanced queries and repository usage.
-- Add incremental query support building on the union constraint so
-  results can update when datasets change without full recomputation.
-  Namespaces will expose a `delta!` operator similar to `pattern!`
-  that receives the previous and current `TribleSet`, calls `union!`
-  internally and matches only the newly added tribles. See the book's
-  [Incremental Queries](book/src/incremental-queries.md) chapter for
-  the planned approach.
 - Explore replacing `CommitSelector` ranges with a set-based API
   built on commit reachability. The goal is to mirror git's revision
   selection semantics (similar to `rev-list` or `rev-parse`).

--- a/book/src/incremental-queries.md
+++ b/book/src/incremental-queries.md
@@ -11,7 +11,7 @@ delta while the remaining constraints see the full updated dataset. Each
 case yields the new solutions introduced by those additions and we then
 union all of the per‑constraint results.
 
-To help express these delta queries at the macro level, namespaces will
+To help express these delta queries at the macro level, namespaces now
 offer a `delta!` operator. It behaves like `pattern!` but takes the
 previous and current `TribleSet`. The macro computes their difference
 and then calls `union!` internally to apply the resulting delta

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -75,8 +75,15 @@ macro_rules! NS {
                 };
             }
 
-            // TODO: incremental queries will eventually use a dedicated `delta!`
-            // macro that applies semi-naive rewriting on a per-triple basis.
+            #[macro_pub::macro_pub]
+            macro_rules! delta {
+                ($prev:expr, $curr:expr, $pattern: tt) => {
+                    {
+                        ::tribles_macros::delta!{ ::tribles, $mod_name, $prev, $curr, $pattern }
+                    }
+                };
+            }
+
         }
     };
 }
@@ -180,6 +187,58 @@ mod tests {
         let r: Vec<_> = find!(
             (author, hamlet, title),
             literature::pattern!(&kb, [
+            {author @
+             firstname: ("William"),
+             lastname: ("Shakespeare")},
+            {hamlet @
+                title: title,
+                author: author
+            }])
+        )
+        .collect();
+
+        assert_eq!(
+            vec![(
+                shakespeare.to_value(),
+                hamlet.to_value(),
+                "Hamlet".to_value(),
+            )],
+            r
+        );
+    }
+
+    #[test]
+    fn ns_delta() {
+        let mut base = TribleSet::new();
+        (0..10).for_each(|_| {
+            let a = ufoid();
+            let b = ufoid();
+            base += literature::entity!(&a, {
+                firstname: Name(EN).fake::<String>(),
+                lastname: Name(EN).fake::<String>()
+            });
+            base += literature::entity!(&b, {
+                title: Name(EN).fake::<String>(),
+                author: &a
+            });
+        });
+
+        let mut updated = base.clone();
+        let shakespeare = ufoid();
+        let hamlet = ufoid();
+        updated += literature::entity!(&shakespeare, {
+            firstname: "William",
+            lastname: "Shakespeare"
+        });
+        updated += literature::entity!(&hamlet, {
+            title: "Hamlet",
+            author: &shakespeare,
+            quote: "To be, or not to be, that is the question.".to_blob().get_handle()
+        });
+
+        let r: Vec<_> = find!(
+            (author, hamlet, title),
+            literature::delta!(&base, &updated, [
             {author @
              firstname: ("William"),
              lastname: ("Shakespeare")},


### PR DESCRIPTION
## Summary
- implement `delta!` as a procedural macro
- expose `delta!` from namespaces
- add a namespace test for delta queries
- document the macro and mark it complete in the inventory
- refine the `delta!` implementation to combine repeated constraints once

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68803ba34dd08322b06e7829cca2cb7d