### PR TITLE
Fix range commit selector semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via set operations, matching Git's two-dot semantics even across merges.
 - Added a `symmetric_diff` selector corresponding to Git's `A...B` three-dot
   syntax.
+- `RangeFrom` now returns `ancestors(head)` minus `ancestors(start)` while
+  `..c` selects `ancestors(c)` and `..` resolves to `ancestors(head)`. The old
+  `collect_range` and `first_parent` helpers were removed.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -140,8 +140,8 @@ fn workspace_checkout_range_variants() {
     s1s2s3.union(sets[2].clone());
 
     assert_eq!(ws.checkout(c1..c3).unwrap(), s2s3.clone());
-    assert_eq!(ws.checkout(c2..).unwrap(), s2s3.clone());
-    assert_eq!(ws.checkout(..c3).unwrap(), s1s2.clone());
+    assert_eq!(ws.checkout(c2..).unwrap(), sets[2].clone());
+    assert_eq!(ws.checkout(..c3).unwrap(), s1s2s3.clone());
     assert_eq!(ws.checkout(..).unwrap(), s1s2s3);
 }
 


### PR DESCRIPTION
## Summary
- align `RangeFrom`, `RangeTo`, and `RangeFull` selectors with git-like set semantics
- remove the obsolete `collect_range` and `first_parent` helpers
- adjust workspace tests for new selector behaviour
- document the change in `CHANGELOG.md`

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6881020bcd008322a75f22fd40f0ac5a