### PR TITLE
Document commit range semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implementation.
 - Recorded tasks to benchmark PATCH, analyze its algorithmic complexity and
   measure real-world space usage.
+- Documented commit range semantics explaining that `a..b` equals
+  `ancestors(b) - ancestors(a)` with missing endpoints defaulting to an empty set
+  and the current `HEAD`.
 
 ### Changed
 - Removed the experimental `delta!` macro implementation; incremental

--- a/book/src/commit-selectors.md
+++ b/book/src/commit-selectors.md
@@ -3,7 +3,12 @@
 The current `Workspace::checkout` API accepts a `CommitSelector` trait which is
 implemented for individual handles and standard Rust ranges. While convenient,
 this range-based design makes it difficult to compose complex queries over the
-commit graph.
+commit graph. Range selectors follow Git's two‑dot semantics: `a..b` selects
+all commits reachable from `b` that are not reachable from `a`. In set terms it
+computes `ancestors(b) - ancestors(a)`. When the start is omitted, `a`
+defaults to the empty set so `..b` simply yields `ancestors(b)`. When the end is
+omitted, `b` defaults to the current `HEAD` and `a..` resolves to
+`ancestors(HEAD) - ancestors(a)` while `..` expands to `ancestors(HEAD)`.
 
 A future redesign could mirror Git's revision selection semantics.
 Instead of passing ranges, callers would construct *commit sets* derived from

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -31,7 +31,10 @@ repo.push(&mut ws)?;
 You can inspect previous commits using `Workspace::checkout` which returns a
 `TribleSet` with the union of the specified commit contents. Passing a single
 commit returns just that commit. To include its history you can use the
-`ancestors` helper. Commit ranges are supported for convenience:
+`ancestors` helper. Commit ranges are supported for convenience. The
+expression `a..b` yields every commit reachable from `b` that is not
+reachable from `a`, treating missing endpoints as empty (`..b`) or the current
+`HEAD` (`a..` and `..`):
 
 ```rust
 let history = ws.checkout(commit_a..commit_b)?;


### PR DESCRIPTION
## Summary
- document commit ranges in the commit selectors doc
- clarify range semantics in the repository workflows guide
- add changelog entry for the new docs

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68811ca6e1848322abb27e7e38ec2bc3