### PR TITLE
Remove done items from inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,12 +85,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented commit range semantics explaining that `a..b` equals
   `ancestors(b) - ancestors(a)` with missing endpoints defaulting to an empty set
   and the current `HEAD`.
+- Compressed zero-copy archives are now complete.
+- Incremental queries use a new `pattern_changes!` macro.
 
 ### Changed
 - README no longer labels compressed zero-copy archives as WIP.
 - Switched from `sucds` to `jerky` for succinct data structures and reworked
   compressed archives to use it directly.
 - Construct archive prefix bit vectors using `BitVectorBuilder::from_bit`.
+- Removed completed tasks from `INVENTORY.md` and recorded them here.
 - Removed the experimental `delta!` macro implementation; incremental
   query support will be revisited once `pattern!` becomes a procedural
   macro.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -3,12 +3,6 @@
 ## Potential Removals
 - None at the moment.
 
-## Completed Work
-- Compressed zero-copy archives are complete.
-- Implemented a `pattern_changes!` macro for incremental queries. The macro
-  takes the current dataset and a precomputed changeset, unioning per-triple
-  results so callers only see newly inserted data.
-
 ## Desired Functionality
 - Provide additional examples showcasing advanced queries and repository usage.
 - Explore replacing `CommitSelector` ranges with a set-based API


### PR DESCRIPTION
## Summary
- remove Completed Work section from `INVENTORY.md`
- note zero-copy archive completion and the new `pattern_changes!` macro in the changelog
- record inventory cleanup in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6881252e0e008322a44bd2a75d3b0188