### PR TITLE
Document richer schema ideas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implementation.
 - Recorded tasks to benchmark PATCH, analyze its algorithmic complexity and
   measure real-world space usage.
+- Listed candidate built-in schemas with design notes in `INVENTORY.md` for
+  future implementation.
 
 ### Changed
 - Removed the experimental `delta!` macro implementation; incremental
@@ -159,6 +161,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via set operations, matching Git's two-dot semantics even across merges.
 - Added a `symmetric_diff` selector corresponding to Git's `A...B` three-dot
   syntax.
+- Refined candidate built-in schemas in `INVENTORY.md`; removed `Bool`, the
+  `BinaryLargeObject` placeholder, and the 64-bit integer types.
+- Expanded the built-in schema ideas with a fuller list of value and blob
+  formats to explore.
+- Brainstormed an even broader range of potential schemas for long-term
+  consideration.
+- Added Lance, neural-network, vector-search and full-text index formats to the
+  candidate blob schemas, with a note to favor memory-mapped Rust crates.
+- Trimmed the candidate schemas, dropping seldom-used formats like neural
+  networks, search indexes, media and font types.
+- Reinstated the neural-network, HNSW and full-text index schema ideas and
+  removed the tar/zip archive formats.
+- Added `SocketAddr` and `RgbaColor` value types alongside a `CompressedBlob`
+  wrapper, while dropping `DateYMD` and `TimeOfDay` from consideration.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -31,6 +31,45 @@
 - Investigate the theoretical complexity of PATCH operations.
 - Measure practical space usage for PATCH with varying dataset sizes.
 
+## Additional Built-in Schemas
+The existing collection of schemas covers the basics like strings, large
+integers and archives.  The following ideas could broaden what can be stored
+without custom extensions:
+
+### Value schemas
+- `Uuid` for RFC&nbsp;4122 identifiers.
+- `Ipv4Addr` and `Ipv6Addr` to store network addresses.  IPv6 could dedicate
+  spare bits to a port or service code.
+- `SocketAddr` representing an IP address and port in one value.
+- `MacAddr` for layer‑2 hardware addresses.
+- `NsTAIInstant` as a single TAI timestamp for precise event records.
+- `Duration` for relative time spans.
+- `GeoPoint` with latitude and longitude stored as two 64‑bit floats.
+- `RgbaColor` packing four 8‑bit channels into one value.
+- `BigDecimal` for high‑precision numbers up to 256 bits.
+
+### Blob schemas
+- `Json`, `Cbor` and `Yaml` for structured data interchange.
+- `Csv` for comma‑separated tables.
+- `Protobuf` or `MessagePack` for compact typed messages.
+- `Parquet` and `Arrow` for columnar analytics workloads.
+- `Lance` for memory-mapped columnar datasets.
+- `CompressedBlob` wrapping arbitrary content with deflate or zip compression.
+- `WasmModule` for executable WebAssembly.
+- `OnnxModel` or `Safetensors` for neural networks.
+- `HnswIndex` for vector search structures.
+- `TantivyIndex` capturing a full-text search corpus.
+- `Url` for web links and other IRIs; best stored as a blob due to the value
+  size limit.
+- `Html` or `Xml` for markup documents.
+- `Markdown` for portable text.
+- `Svg` for vector graphics.
+- `Png` and `Jpeg` images.
+- `Pdf` for print‑ready documents.
+
+Formats with solid memory-mapping support in the Rust ecosystem should be
+prioritized for efficient zero-copy access.
+
 ## Documentation
 - Move the "Portability & Common Formats" overview from `src/value.rs` into a
   dedicated chapter of the book.


### PR DESCRIPTION
## Summary
- refine candidate built-in schemas
- keep neural-network, vector search and full-text index formats
- track changes in the changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688108342ae083229fe4963528a810d8