### PR TITLE
Add matches! macro for boolean queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the current `HEAD`.
 - Compressed zero-copy archives are now complete.
 - Incremental queries use a new `pattern_changes!` macro.
+- Added a `matches!` macro mirroring `find!` for boolean checks.
 
 ### Changed
 - README no longer labels compressed zero-copy archives as WIP.

--- a/book/src/query-language.md
+++ b/book/src/query-language.md
@@ -61,6 +61,18 @@ This query searches the example dataset for the book titled "Dune".  The
 variables and constraint can be adapted to express more complex joins and
 filters.
 
+## `matches!`
+
+Sometimes you only want to check whether a constraint has any solutions.
+The `matches!` macro mirrors the `find!` syntax but returns a boolean:
+
+```rust
+use tribles::prelude::*;
+
+assert!(matches!((x), x.is(1.into())));
+assert!(!matches!((x), and!(x.is(1.into()), x.is(2.into()))));
+```
+
 ## Custom constraints
 
 Every building block implements the

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -38,6 +38,7 @@ pub use crate::namespace::NS;
 pub use crate::query::{
     find,
     intersectionconstraint::{and, IntersectionConstraint},
+    matches,
 };
 pub use crate::repo::pile::Pile;
 pub use crate::repo::{BlobStore, BlobStoreGet, BlobStoreList, BlobStorePut, BranchStore};

--- a/src/query.rs
+++ b/src/query.rs
@@ -581,6 +581,14 @@ macro_rules! find {
 }
 pub use find;
 
+#[macro_export]
+macro_rules! matches {
+    (($($Var:tt$(:$Ty:ty)?),+), $Constraint:expr) => {
+        $crate::query::find!(($($Var$(:$Ty)?),+), $Constraint).next().is_some()
+    };
+}
+pub use matches;
+
 #[cfg(test)]
 mod tests {
     use valueschemas::ShortString;
@@ -712,5 +720,18 @@ mod tests {
         let r: Vec<_> = q.collect();
 
         assert_eq!(1, r.len())
+    }
+
+    #[test]
+    fn matches_true() {
+        assert!(matches!((a: Value<_>), a.is(I256BE::value_from(42))));
+    }
+
+    #[test]
+    fn matches_false() {
+        assert!(!matches!(
+            (a: Value<_>),
+            and!(a.is(I256BE::value_from(1)), a.is(I256BE::value_from(2)))
+        ));
     }
 }

--- a/src/value/schemas/hash.rs
+++ b/src/value/schemas/hash.rs
@@ -201,6 +201,6 @@ mod tests {
         let s: &str = "blake3:BAD!";
         let err: HashError = <&str as TryToValue<Hash<Blake3>>>::try_to_value(s)
             .expect_err("packing invalid protocol should fail");
-        assert!(matches!(err, HashError::BadHex(..)));
+        assert!(std::matches!(err, HashError::BadHex(..)));
     }
 }


### PR DESCRIPTION
## Summary
- implement `matches!` macro in `query` and re-export in prelude
- add tests covering `matches!`
- document the macro in the query language guide
- note the new macro in the changelog
- disambiguate uses of `std::matches!`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688172aea30c8322b399fc753b1f4264