### PR TITLE
Switch to git anybytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incremental queries use a new `pattern_changes!` macro.
 
 ### Changed
+- Switched `anybytes` to a git dependency and used its `Bytes` integration
+  to avoid copying blob data when writing to object stores.
 - README no longer labels compressed zero-copy archives as WIP.
 - Switched from `sucds` to `jerky` for succinct data structures and reworked
   compressed archives to use it directly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 memmap2 = "0.9.5"
 zerocopy = { version = "0.8", features = ["derive"] }
-anybytes = {version = "0.19.3", features = ["bytes", "zerocopy"]}
+anybytes = { git = "https://github.com/triblespace/anybytes", features = ["bytes", "zerocopy"] }
 rand = "0.8"
 digest = "0.10.7"
 ux = "0.1.5"

--- a/src/repo/objectstore.rs
+++ b/src/repo/objectstore.rs
@@ -114,7 +114,7 @@ where
         let blob = item.to_blob();
         let handle = blob.get_handle();
         let path = self.prefix.child(BLOB_INFIX).child(hex::encode(handle.raw));
-        let bytes = bytes::Bytes::copy_from_slice(&blob.bytes);
+        let bytes: bytes::Bytes = blob.bytes.into();
         let result = block_on(async {
             self.store
                 .put_opts(&path, bytes.into(), PutMode::Create.into())


### PR DESCRIPTION
## Summary
- update `anybytes` to a git dependency
- avoid copying when uploading blobs to object stores

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68817ca5df5083229b8943f28415f7a9