### PR TITLE
Implement procedural namespace macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `entity!` now implemented as a procedural macro alongside `pattern!`.
 - `entity!` subsumes the old `entity_inner!` helper; macro invocations can
   optionally provide an existing `TribleSet`.
+- Procedural `namespace!` macro replaces the declarative `NS!` implementation.
 - Implemented a procedural `delta!` macro for incremental query support.
 - Expanded documentation for the `pattern` procedural macro to ease maintenance, including detailed comments inside the implementation.
 - `EntityId` variants renamed to `Var` and `Lit` for consistency with field patterns.

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -17,74 +17,11 @@ pub use hex_literal;
 
 /// Defines a Rust module to represent a namespace, along with convenience macros.
 /// The `namespace` block maps human-readable names to attribute IDs and type schemas.
+
 #[macro_export]
 macro_rules! NS {
-    ($(#[doc = $ns_doc:literal])* $visibility:vis namespace $mod_name:ident {$($(#[doc = $field_doc:literal])* $FieldId:literal as $FieldName:ident: $FieldType:ty;)*}) => {
-        $(#[doc=$ns_doc])*
-        $visibility mod $mod_name {
-            #![allow(unused)]
-            use super::*;
-
-            pub fn description() -> $crate::trible::TribleSet {
-                use $crate::value::ValueSchema;
-
-                let mut set = $crate::trible::TribleSet::new();
-                $({let e = $crate::id::Id::new($crate::namespace::hex_literal::hex!($FieldId)).unwrap();
-                   let value_schema_id = $crate::value::schemas::genid::GenId::value_from(<$FieldType as $crate::value::ValueSchema>::VALUE_SCHEMA_ID);
-                   set.insert(&$crate::trible::Trible::force(&e, &$crate::metadata::ATTR_VALUE_SCHEMA, &value_schema_id));
-                   if let Some(blob_schema_id) = <$FieldType as $crate::value::ValueSchema>::BLOB_SCHEMA_ID {
-                      let blob_schema_id = $crate::value::schemas::genid::GenId::value_from(blob_schema_id);
-                      set.insert(&$crate::trible::Trible::force(&e, &$crate::metadata::ATTR_BLOB_SCHEMA, &blob_schema_id));
-                   }
-                   let attr_name = $crate::value::schemas::shortstring::ShortString::value_from(stringify!($FieldName));
-                   set.insert(&$crate::trible::Trible::force(&e, &$crate::metadata::ATTR_NAME, &attr_name));
-                })*
-                set
-            }
-            pub mod ids {
-                #![allow(non_upper_case_globals, unused)]
-                use super::*;
-                $($(#[doc = $field_doc])* pub const $FieldName:$crate::id::Id = $crate::id::Id::new($crate::namespace::hex_literal::hex!($FieldId)).unwrap();)*
-            }
-            pub mod schemas {
-                #![allow(non_camel_case_types, unused)]
-                use super::*;
-                $($(#[doc = $field_doc])* pub type $FieldName = $FieldType;)*
-            }
-
-            #[macro_pub::macro_pub]
-            macro_rules! entity {
-                ($entity:tt) => {
-                    {
-                        ::tribles_macros::entity!(::tribles, $mod_name, $entity)
-                    }
-                };
-                ($entity_id:expr, $entity:tt) => {
-                    {
-                        ::tribles_macros::entity!(::tribles, $mod_name, $entity_id, $entity)
-                    }
-                };
-            }
-
-            #[macro_pub::macro_pub]
-            macro_rules! pattern {
-                ($set:expr, $pattern: tt) => {
-                    {
-                        ::tribles_macros::pattern!{ ::tribles, $mod_name, $set, $pattern }
-                    }
-                };
-            }
-
-            #[macro_pub::macro_pub]
-            macro_rules! pattern_changes {
-                ($curr:expr, $changes:expr, $pattern: tt) => {
-                    {
-                        ::tribles_macros::pattern_changes!{ ::tribles, $mod_name, $curr, $changes, $pattern }
-                    }
-                };
-            }
-
-        }
+    ($($tt:tt)*) => {
+        ::tribles_macros::namespace!(::tribles, $($tt)*);
     };
 }
 

--- a/tribles-macros/src/lib.rs
+++ b/tribles-macros/src/lib.rs
@@ -35,6 +35,16 @@ use syn::parse::{Parse, ParseStream};
 use syn::{braced, bracketed, parenthesized, Token};
 use syn::{Expr, Ident, Path};
 
+mod namespace;
+
+#[proc_macro]
+pub fn namespace(input: TokenStream) -> TokenStream {
+    match namespace::namespace_impl(input) {
+        Ok(ts) => ts,
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
 /// Parsed input for the [`pattern`] macro.
 ///
 /// The invocation has the form `crate_path, namespace_path, dataset, [ .. ]`.

--- a/tribles-macros/src/namespace.rs
+++ b/tribles-macros/src/namespace.rs
@@ -1,0 +1,161 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{braced, Attribute, Ident, LitStr, Path, Token, Type, Visibility};
+
+mod kw {
+    syn::custom_keyword!(namespace);
+}
+
+struct Field {
+    attrs: Vec<Attribute>,
+    id: LitStr,
+    name: Ident,
+    ty: Type,
+}
+
+struct NamespaceInput {
+    crate_path: Path,
+    attrs: Vec<Attribute>,
+    vis: Visibility,
+    mod_name: Ident,
+    fields: Vec<Field>,
+}
+
+impl Parse for NamespaceInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let crate_path: Path = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let attrs = input.call(Attribute::parse_outer)?;
+        let vis: Visibility = input.parse()?;
+        input.parse::<kw::namespace>()?;
+        let mod_name: Ident = input.parse()?;
+
+        let content;
+        braced!(content in input);
+        let mut fields = Vec::new();
+        while !content.is_empty() {
+            let f_attrs = content.call(Attribute::parse_outer)?;
+            let id: LitStr = content.parse()?;
+            content.parse::<Token![as]>()?;
+            let name: Ident = content.parse()?;
+            content.parse::<Token![:]>()?;
+            let ty: Type = content.parse()?;
+            content.parse::<Token![;]>()?;
+            fields.push(Field {
+                attrs: f_attrs,
+                id,
+                name,
+                ty,
+            });
+        }
+
+        Ok(NamespaceInput {
+            crate_path,
+            attrs,
+            vis,
+            mod_name,
+            fields,
+        })
+    }
+}
+
+pub(crate) fn namespace_impl(input: TokenStream) -> syn::Result<TokenStream> {
+    let NamespaceInput {
+        crate_path,
+        attrs,
+        vis,
+        mod_name,
+        fields,
+    } = syn::parse(input)?;
+
+    let desc_fields = fields.iter().map(|Field { id, name, ty, .. }| {
+        quote! {
+            {
+                let e = #crate_path::id::Id::new(#crate_path::namespace::hex_literal::hex!(#id)).unwrap();
+                let value_schema_id = #crate_path::value::schemas::genid::GenId::value_from(<#ty as #crate_path::value::ValueSchema>::VALUE_SCHEMA_ID);
+                set.insert(&#crate_path::trible::Trible::force(&e, &#crate_path::metadata::ATTR_VALUE_SCHEMA, &value_schema_id));
+                if let Some(blob_schema_id) = <#ty as #crate_path::value::ValueSchema>::BLOB_SCHEMA_ID {
+                    let blob_schema_id = #crate_path::value::schemas::genid::GenId::value_from(blob_schema_id);
+                    set.insert(&#crate_path::trible::Trible::force(&e, &#crate_path::metadata::ATTR_BLOB_SCHEMA, &blob_schema_id));
+                }
+                let attr_name = #crate_path::value::schemas::shortstring::ShortString::value_from(stringify!(#name));
+                set.insert(&#crate_path::trible::Trible::force(&e, &#crate_path::metadata::ATTR_NAME, &attr_name));
+            }
+        }
+    });
+
+    let ids_consts = fields.iter().map(|Field { attrs, id, name, .. }| {
+        quote! { #(#attrs)* pub const #name: #crate_path::id::Id = #crate_path::id::Id::new(#crate_path::namespace::hex_literal::hex!(#id)).unwrap(); }
+    });
+
+    let schema_types = fields.iter().map(
+        |Field {
+             attrs, name, ty, ..
+         }| {
+            quote! { #(#attrs)* pub type #name = #ty; }
+        },
+    );
+
+    let entity_macro = quote! {
+        #[macro_pub::macro_pub]
+        macro_rules! entity {
+            ($entity:tt) => {{
+                ::tribles_macros::entity!(::tribles, #mod_name, $entity)
+            }};
+            ($entity_id:expr, $entity:tt) => {{
+                ::tribles_macros::entity!(::tribles, #mod_name, $entity_id, $entity)
+            }};
+        }
+    };
+
+    let pattern_macro = quote! {
+        #[macro_pub::macro_pub]
+        macro_rules! pattern {
+            ($set:expr, $pattern: tt) => {{
+                ::tribles_macros::pattern!(::tribles, #mod_name, $set, $pattern)
+            }};
+        }
+    };
+
+    let pattern_changes_macro = quote! {
+        #[macro_pub::macro_pub]
+        macro_rules! pattern_changes {
+            ($curr:expr, $changes:expr, $pattern: tt) => {{
+                ::tribles_macros::pattern_changes!(::tribles, #mod_name, $curr, $changes, $pattern)
+            }};
+        }
+    };
+
+    let output = quote! {
+        #(#attrs)*
+        #vis mod #mod_name {
+            #![allow(unused)]
+            use super::*;
+
+            pub fn description() -> #crate_path::trible::TribleSet {
+                use #crate_path::value::ValueSchema;
+
+                let mut set = #crate_path::trible::TribleSet::new();
+                #(#desc_fields)*
+                set
+            }
+            pub mod ids {
+                #![allow(non_upper_case_globals, unused)]
+                use super::*;
+                #(#ids_consts)*
+            }
+            pub mod schemas {
+                #![allow(non_camel_case_types, unused)]
+                use super::*;
+                #(#schema_types)*
+            }
+            #entity_macro
+            #pattern_macro
+            #pattern_changes_macro
+        }
+    };
+
+    Ok(output.into())
+}


### PR DESCRIPTION
## Summary
- add procedural `namespace` macro parsing docs, fields, vis and module name
- export the macro from `tribles-macros`
- call the new procedural macro from `NS!`
- update changelog

## Testing
- `./scripts/preflight.sh` *(fails: stack overflow in `ids_compressed` test)*

------
https://chatgpt.com/codex/tasks/task_e_68816904f1748322b0a267486dec4862