### PR TITLE
Fix timestamp schema ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented commit range semantics explaining that `a..b` equals
   `ancestors(b) - ancestors(a)` with missing endpoints defaulting to an empty set
   and the current `HEAD`.
+- Commits now record a `timestamp` using `NsTAIInterval` and workspaces provide a
+  `TimeRange` selector to gather commits between two instants.
 - Compressed zero-copy archives are now complete.
 - Incremental queries use a new `pattern_changes!` macro.
 

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -22,6 +22,8 @@
 - Implement a garbage collection mechanism that scans branch and commit
   archives without fully deserialising them to find reachable blob handles.
   Anything not discovered this way can be forgotten by the underlying store.
+- Support time-based commit queries via a `TimeRange` selector leveraging
+  commit timestamps.
 
 ## Additional Built-in Schemas
 The existing collection of schemas covers the basics like strings, large
@@ -34,7 +36,6 @@ without custom extensions:
   spare bits to a port or service code.
 - `SocketAddr` representing an IP address and port in one value.
 - `MacAddr` for layer‑2 hardware addresses.
-- `NsTAIInstant` as a single TAI timestamp for precise event records.
 - `Duration` for relative time spans.
 - `GeoPoint` with latitude and longitude stored as two 64‑bit floats.
 - `RgbaColor` packing four 8‑bit channels into one value.

--- a/book/src/commit-selectors.md
+++ b/book/src/commit-selectors.md
@@ -55,3 +55,23 @@ than commits are listed for completeness but are unlikely to be implemented.
 
 Only a subset of Git's revision grammar will likely be supported. Selectors relying on reflog history, remote configuration, or searching commits and blobs add complexity with little benefit for workspace checkout. They are listed above for completeness but remain unplanned for now.
 
+## TimeRange
+
+Commits record when they were made via a `timestamp` attribute of type
+[`NsTAIInterval`](../src/value/schemas/time.rs). When creating a commit this
+interval defaults to `(now, now)` but other tools could provide a wider range
+if the clock precision is uncertain. The `TimeRange` selector uses this interval
+to gather commits whose timestamps fall between two `Epoch` values:
+
+```rust
+use hifitime::Epoch;
+use tribles::repo::time_range;
+
+let since = Epoch::from_unix_seconds(1_609_459_200.0); // 2020-12-01
+let now = Epoch::now().unwrap();
+let tribles = ws.checkout(time_range(since, now))?;
+```
+
+This walks the history from `HEAD` and returns only those commits whose
+timestamp interval intersects the inclusive range.
+

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -113,6 +113,7 @@ use std::{
 };
 
 use commit::commit;
+use hifitime::Epoch;
 use itertools::Itertools;
 
 use crate::{blob::MemoryBlobStore, repo::branch::branch};
@@ -138,7 +139,7 @@ use ed25519_dalek::SigningKey;
 
 use crate::{
     blob::schemas::simplearchive::SimpleArchive,
-    value::schemas::{ed25519 as ed, hash::Blake3, shortstring::ShortString},
+    value::schemas::{ed25519 as ed, hash::Blake3, shortstring::ShortString, time::NsTAIInterval},
 };
 
 NS! {
@@ -161,6 +162,8 @@ NS! {
         /// An id used to track the branch.
         /// This id is unique to the branch, and is used to identify the branch in the repository.
         "8694CC73AF96A5E1C7635C677D1B928A" as branch: GenId;
+        /// Timestamp range when this commit was created.
+        "71FF566AB4E3119FC2C5E66A18979586" as timestamp: NsTAIInterval;
         //"723C45065E7FCF1D52E86AD8D856A20D" as cached_rollup: Handle<Blake3, SuccinctArchive<CachedUniverse<1024, 1024, CompressedUniverse<DacsOpt>>, Rank9Sel>>;
         /// The author of the signature identified by their ed25519 public key.
         "ADB4FFAD247C886848161297EFF5A05B" as signed_by: ed::ED25519PublicKey;
@@ -866,6 +869,14 @@ pub fn symmetric_diff(a: CommitHandle, b: CommitHandle) -> SymmetricDiff {
     SymmetricDiff(a, b)
 }
 
+/// Selector that returns commits with timestamps in the given inclusive range.
+pub struct TimeRange(pub Epoch, pub Epoch);
+
+/// Convenience function to create a [`TimeRange`] selector.
+pub fn time_range(start: Epoch, end: Epoch) -> TimeRange {
+    TimeRange(start, end)
+}
+
 impl<Blobs> CommitSelector<Blobs> for CommitHandle
 where
     Blobs: BlobStore<Blake3>,
@@ -1019,6 +1030,22 @@ where
     > {
         let head = ws.head.ok_or(WorkspaceCheckoutError::NoHead)?;
         collect_reachable(ws, head)
+    }
+}
+
+impl<Blobs> CommitSelector<Blobs> for TimeRange
+where
+    Blobs: BlobStore<Blake3>,
+{
+    fn select(
+        self,
+        ws: &mut Workspace<Blobs>,
+    ) -> Result<
+        CommitSet,
+        WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+    > {
+        let head = ws.head.ok_or(WorkspaceCheckoutError::NoHead)?;
+        collect_time_range(ws, head, self.0, self.1)
     }
 }
 
@@ -1238,6 +1265,48 @@ fn collect_reachable<Blobs: BlobStore<Blake3>>(
 
         for (p,) in find!((p: Value<_>), repo::pattern!(&meta, [{ parent: p }])) {
             stack.push(p);
+        }
+    }
+
+    Ok(result)
+}
+
+fn collect_time_range<Blobs: BlobStore<Blake3>>(
+    ws: &mut Workspace<Blobs>,
+    from: CommitHandle,
+    start: Epoch,
+    end: Epoch,
+) -> Result<
+    CommitSet,
+    WorkspaceCheckoutError<<Blobs::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>>,
+> {
+    let mut visited = HashSet::new();
+    let mut stack = vec![from];
+    let mut result = CommitSet::new();
+
+    while let Some(commit) = stack.pop() {
+        if !visited.insert(commit) {
+            continue;
+        }
+
+        let meta: TribleSet = ws
+            .local_blobs
+            .reader()
+            .get(commit)
+            .or_else(|_| ws.base_blobs.get(commit))
+            .map_err(WorkspaceCheckoutError::Storage)?;
+
+        for (p,) in find!((p: Value<_>), repo::pattern!(&meta, [{ parent: p }])) {
+            stack.push(p);
+        }
+
+        if let Ok(Some((ts,))) =
+            find!((t: Value<_>), repo::pattern!(&meta, [{ timestamp: t }])).at_most_one()
+        {
+            let (ts_start, ts_end): (Epoch, Epoch) = crate::value::FromValue::from_value(&ts);
+            if ts_start <= end && ts_end >= start {
+                result.insert(&Entry::new(&commit.raw));
+            }
         }
     }
 

--- a/src/repo/commit.rs
+++ b/src/repo/commit.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 use crate::value::schemas::hash::Blake3;
+use hifitime::Epoch;
 
 pub enum ValidationError {
     AmbiguousSignature,
@@ -41,6 +42,9 @@ pub fn commit(
 ) -> TribleSet {
     let mut commit = TribleSet::new();
     let commit_entity = crate::id::rngid();
+    let now = Epoch::now().expect("system time");
+
+    commit += repo::entity!(&commit_entity, { timestamp: (now, now) });
 
     if let Some(content) = content {
         let handle = content.get_handle();


### PR DESCRIPTION
## Summary
- regenerate the commit timestamp schema identifier

## Testing
- `cargo test --quiet` *(fails: stack overflow in `ids_compressed`)*
- `./scripts/preflight.sh` *(fails during tests: stack overflow in `ids_compressed`)*

------
https://chatgpt.com/codex/tasks/task_e_68816b9888f0832298829922eceed562