### PR TITLE
Add commit filter selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compressed zero-copy archives are now complete.
 - Incremental queries use a new `pattern_changes!` macro.
 - Added a `matches!` macro mirroring `find!` for boolean checks.
+- Added a `filter` commit selector with a `history_of` helper.
 
 ### Changed
 - Switched `anybytes` to a git dependency and used its `Bytes` integration

--- a/book/src/commit-selectors.md
+++ b/book/src/commit-selectors.md
@@ -22,6 +22,18 @@ This approach aligns with Git's mental model and keeps selection logic separate
 from workspace mutation.  It also opens the door for additional operations on
 commit sets without complicating the core API.
 
+## Filtering commits
+
+The `filter` selector wraps another selector and keeps only the commits for
+which a user provided closure returns `true`. The closure receives the commit
+metadata and its payload. Higher level helpers can build on this primitive. For
+example `history_of(entity)` filters `ancestors(HEAD)` to commits touching a
+specific entity:
+
+```rust
+let changes = ws.checkout(history_of(my_entity))?;
+```
+
 ## Git Comparison
 
 The table below summarizes Git's revision grammar. Each row links back to the

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -41,6 +41,13 @@ let history = ws.checkout(commit_a..commit_b)?;
 let full = ws.checkout(ancestors(commit_b))?;
 ```
 
+The [`history_of`](../src/repo.rs) helper builds on the `filter` selector to
+retrieve only the commits affecting a specific entity:
+
+```rust
+let entity_changes = ws.checkout(history_of(my_entity))?;
+```
+
 ## Merging and Conflict Handling
 
 When pushing a workspace another client might have already updated the branch.


### PR DESCRIPTION
## Summary
- add `Filter` commit selector and convenience `history_of`
- document filtering commits in the book and mention the helper
- test history_of in workspace tests
- update changelog
- refactor `filter` selector to use workspace `get` for blob retrieval

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6881691c0fb88322ad5d6c881c6bfdbe