### PR TITLE
Add influence method to Constraint trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README now links to the corresponding chapters on https://triblespace.github.io/tribles-rust.
 - `branch_id_by_name` helper to resolve branch IDs from names. Returns a
   `NameConflict` error when multiple branches share the same name.
+- `Constraint::influence` method for identifying dependent variables.
 - Documentation and examples for the repository API.
 - Test coverage for `branch_from` and `pull_with_key`.
 - `Workspace::checkout` helper to load commit contents.

--- a/benches/query.rs
+++ b/benches/query.rs
@@ -1,0 +1,7 @@
+#![allow(unused)]
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_placeholder(_c: &mut Criterion) {}
+
+criterion_group!(benches, bench_placeholder);
+criterion_main!(benches);

--- a/src/query/intersectionconstraint.rs
+++ b/src/query/intersectionconstraint.rs
@@ -63,6 +63,14 @@ where
             .iter()
             .for_each(|(_, c)| c.confirm(variable, binding, proposals));
     }
+
+    fn influence(&self, variable: VariableId) -> VariableSet {
+        self.constraints
+            .iter()
+            .fold(VariableSet::new_empty(), |acc, c| {
+                acc.union(c.influence(variable))
+            })
+    }
 }
 
 #[macro_export]

--- a/src/query/unionconstraint.rs
+++ b/src/query/unionconstraint.rs
@@ -61,6 +61,14 @@ where
 
         _ = mem::replace(proposals, union);
     }
+
+    fn influence(&self, variable: VariableId) -> VariableSet {
+        self.constraints
+            .iter()
+            .fold(VariableSet::new_empty(), |acc, c| {
+                acc.union(c.influence(variable))
+            })
+    }
 }
 
 #[macro_export]


### PR DESCRIPTION
## Summary
- add `Constraint::influence` with default implementation
- expose influence for boxed and arc constraints
- compute influence for `IntersectionConstraint` and `UnionConstraint`
- create placeholder `benches/query.rs`
- document new API in changelog
- use recursive `influence` call for composite constraints

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883c217a3988322ba62deac39b68790