### PR TITLE
Add variable ordering debug helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Workspace::checkout` helper to load commit contents.
 - `pattern!` now implemented as a procedural macro in the new `tribles-macros` crate.
 - `entity!` now implemented as a procedural macro alongside `pattern!`.
+- Debug helpers `EstimateOverrideConstraint` and `DebugConstraint` moved to a new
+  `debug` module.
 - `entity!` subsumes the old `entity_inner!` helper; macro invocations can
   optionally provide an existing `TribleSet`.
 - Procedural `namespace!` macro replaces the declarative `NS!` implementation.

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,87 @@
+pub mod query {
+    use crate::query::{Binding, Constraint, VariableId, VariableSet};
+    use crate::value::RawValue;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    pub struct DebugConstraint<C> {
+        pub constraint: C,
+        pub record: Rc<RefCell<Vec<VariableId>>>,
+    }
+
+    impl<C> DebugConstraint<C> {
+        pub fn new(constraint: C, record: Rc<RefCell<Vec<VariableId>>>) -> Self {
+            DebugConstraint { constraint, record }
+        }
+    }
+
+    impl<'a, C: Constraint<'a>> Constraint<'a> for DebugConstraint<C> {
+        fn variables(&self) -> VariableSet {
+            self.constraint.variables()
+        }
+
+        fn estimate(&self, variable: VariableId, binding: &Binding) -> Option<usize> {
+            self.constraint.estimate(variable, binding)
+        }
+
+        fn propose(&self, variable: VariableId, binding: &Binding, proposals: &mut Vec<RawValue>) {
+            self.record.borrow_mut().push(variable);
+            self.constraint.propose(variable, binding, proposals);
+        }
+
+        fn confirm(&self, variable: VariableId, binding: &Binding, proposals: &mut Vec<RawValue>) {
+            self.constraint.confirm(variable, binding, proposals);
+        }
+
+        fn influence(&self, variable: VariableId) -> VariableSet {
+            self.constraint.influence(variable)
+        }
+    }
+
+    pub struct EstimateOverrideConstraint<C> {
+        pub constraint: C,
+        pub estimates: [Option<usize>; 128],
+    }
+
+    impl<C> EstimateOverrideConstraint<C> {
+        pub fn new(constraint: C) -> Self {
+            EstimateOverrideConstraint {
+                constraint,
+                estimates: [None; 128],
+            }
+        }
+
+        pub fn with_estimates(constraint: C, estimates: [Option<usize>; 128]) -> Self {
+            EstimateOverrideConstraint {
+                constraint,
+                estimates,
+            }
+        }
+
+        pub fn set_estimate(&mut self, variable: VariableId, estimate: usize) {
+            self.estimates[variable] = Some(estimate);
+        }
+    }
+
+    impl<'a, C: Constraint<'a>> Constraint<'a> for EstimateOverrideConstraint<C> {
+        fn variables(&self) -> VariableSet {
+            self.constraint.variables()
+        }
+
+        fn estimate(&self, variable: VariableId, binding: &Binding) -> Option<usize> {
+            self.estimates[variable].or_else(|| self.constraint.estimate(variable, binding))
+        }
+
+        fn propose(&self, variable: VariableId, binding: &Binding, proposals: &mut Vec<RawValue>) {
+            self.constraint.propose(variable, binding, proposals);
+        }
+
+        fn confirm(&self, variable: VariableId, binding: &Binding, proposals: &mut Vec<RawValue>) {
+            self.constraint.confirm(variable, binding, proposals);
+        }
+
+        fn influence(&self, variable: VariableId) -> VariableSet {
+            self.constraint.influence(variable)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod repo;
 pub mod trible;
 pub mod value;
 
+pub mod debug;
 pub mod examples;
 
 #[cfg(kani)]


### PR DESCRIPTION
## Summary
- move estimate override and debug constraints into new top-level `debug` module
- update query test to use new module

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6884ad17b2a4832280485c16822fc548