### PR TITLE
Add failing estimate override test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Workspace::checkout` now accepts commit ranges for convenient history queries.
 - Git-based terminology notes in the repository guide and a clearer workspace example.
 - Expanded the repository example to store actual data and simplified the conflict loop.
+- Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 - Documentation proposal for exposing blob metadata through the `Pile` API.
 - `IndexEntry` now stores a timestamp for each blob. `PileReader::metadata`
   returns this timestamp along with the blob length.


### PR DESCRIPTION
## Summary
- test variable ordering edge case with EstimateOverrideConstraint should panic
- document the new failing test in the changelog

## Testing
- `./scripts/preflight.sh` *(fails: test did not panic as expected)*

------
https://chatgpt.com/codex/tasks/task_e_6884bdd609c483228d49ae41307a8fc2