### PR TITLE
Fix PatchIdConstraint confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Git-based terminology notes in the repository guide and a clearer workspace example.
 - Expanded the repository example to store actual data and simplified the conflict loop.
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
+### Fixed
+- `PatchIdConstraint` incorrectly used 32-byte values when confirming IDs, causing
+  `local_ids` queries to return no results with overridden estimates.
 - Documentation proposal for exposing blob metadata through the `Pile` API.
 - `IndexEntry` now stores a timestamp for each blob. `PileReader::metadata`
   returns this timestamp along with the blob length.

--- a/src/query/patchconstraint.rs
+++ b/src/query/patchconstraint.rs
@@ -102,7 +102,13 @@ where
     }
 
     fn confirm(&self, _variable: VariableId, _binding: &Binding, proposals: &mut Vec<RawValue>) {
-        proposals.retain(|v| self.patch.has_prefix(v));
+        proposals.retain(|v| {
+            if let Some(id) = crate::id::id_from_value(v) {
+                self.patch.has_prefix(&id)
+            } else {
+                false
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- fix PatchIdConstraint to convert RawValue back to RawId
- add changelog entry

## Testing
- `cargo test ns_local_ids_bad_estimates_panics --quiet`
- `cargo test --quiet`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688668d32b688322b895279c164fcb6a