### PR TITLE
Enforce infix bounds at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `Completed Work` section from `INVENTORY.md`; finished tasks are
   now tracked in this changelog.
 
+### Fixed
+- Enforce `PREFIX_LEN <= KEY_LEN` for prefix checks in PATCH.
+
 ## [0.5.2] - 2025-06-30
 ### Added
 - Initial changelog file.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -73,3 +73,4 @@ prioritized for efficient zero-copy access.
 
 ## Discovered Issues
 - No open issues recorded yet.
+- Enforce `PREFIX_LEN` never exceeds `KEY_LEN` when checking prefixes.

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -438,6 +438,9 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
         at_depth: usize,
         prefix: &[u8; PREFIX_LEN],
     ) -> bool {
+        const {
+            assert!(PREFIX_LEN <= KEY_LEN);
+        }
         match self.body() {
             BodyPtr::Leaf(leaf) => Leaf::has_prefix::<O, PREFIX_LEN>(leaf, at_depth, prefix),
             BodyPtr::Branch(branch) => branch::Branch::has_prefix(branch, at_depth, prefix),
@@ -862,7 +865,7 @@ where
     /// but will usually inferred from the arguments.
     ///
     /// The sum of `PREFIX_LEN` and `INFIX_LEN` must be less than or equal to `KEY_LEN`
-    /// or a panic will occur.
+    /// or a compile-time assertion will fail.
     ///
     /// Because all infixes are iterated in one go, less bookkeeping is required,
     /// than when using an Iterator, allowing for better performance.
@@ -873,13 +876,9 @@ where
     ) where
         F: FnMut(&[u8; INFIX_LEN]),
     {
-        assert!(
-            PREFIX_LEN + INFIX_LEN <= KEY_LEN,
-            "{} + {} > {}",
-            PREFIX_LEN,
-            INFIX_LEN,
-            KEY_LEN
-        );
+        const {
+            assert!(PREFIX_LEN + INFIX_LEN <= KEY_LEN);
+        }
         assert!(
             S::segment(O::key_index(PREFIX_LEN))
                 == S::segment(O::key_index(PREFIX_LEN + INFIX_LEN - 1)),
@@ -895,7 +894,13 @@ where
     }
 
     /// Returns true if the PATCH has a key with the given prefix.
+    ///
+    /// `PREFIX_LEN` must be less than or equal to `KEY_LEN` or a compile-time
+    /// assertion will fail.
     pub fn has_prefix<const PREFIX_LEN: usize>(&self, prefix: &[u8; PREFIX_LEN]) -> bool {
+        const {
+            assert!(PREFIX_LEN <= KEY_LEN);
+        }
         if let Some(root) = &self.root {
             root.has_prefix(0, prefix)
         } else {
@@ -1156,7 +1161,9 @@ impl<
     > PATCHPrefixIterator<'a, KEY_LEN, PREFIX_LEN, O, S>
 {
     fn new(patch: &'a PATCH<KEY_LEN, O, S>) -> Self {
-        assert!(PREFIX_LEN <= KEY_LEN);
+        const {
+            assert!(PREFIX_LEN <= KEY_LEN);
+        }
         let mut r = PATCHPrefixIterator {
             stack: Vec::with_capacity(PREFIX_LEN),
         };

--- a/src/patch/branch.rs
+++ b/src/patch/branch.rs
@@ -360,6 +360,9 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
         at_depth: usize,
         prefix: &[u8; PREFIX_LEN],
     ) -> bool {
+        const {
+            assert!(PREFIX_LEN <= KEY_LEN);
+        }
         unsafe {
             let branch = branch.as_ptr();
             let node_end_depth = (*branch).end_depth as usize;

--- a/src/patch/leaf.rs
+++ b/src/patch/leaf.rs
@@ -109,6 +109,9 @@ impl<const KEY_LEN: usize> Leaf<KEY_LEN> {
         at_depth: usize,
         prefix: &[u8; PREFIX_LEN],
     ) -> bool {
+        const {
+            assert!(PREFIX_LEN <= KEY_LEN);
+        }
         let leaf_key: &[u8; KEY_LEN] = unsafe { &(*leaf.as_ptr()).key };
         for depth in at_depth..PREFIX_LEN {
             if leaf_key[O::key_index(depth)] != prefix[depth] {

--- a/src/query/patchconstraint.rs
+++ b/src/query/patchconstraint.rs
@@ -1,5 +1,5 @@
 use crate::{
-    id::{id_into_value, ID_LEN},
+    id::{id_from_value, id_into_value, ID_LEN},
     patch::{IdentityOrder, SingleSegmentation, PATCH},
     value::{RawValue, ValueSchema, VALUE_LEN},
 };
@@ -102,7 +102,13 @@ where
     }
 
     fn confirm(&self, _variable: VariableId, _binding: &Binding, proposals: &mut Vec<RawValue>) {
-        proposals.retain(|v| self.patch.has_prefix(v));
+        proposals.retain(|v| {
+            if let Some(id) = id_from_value(v) {
+                self.patch.has_prefix(&id)
+            } else {
+                false
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- use const assertions to check infix length constraints
- validate prefix length bounds in the prefix iterator at compile time

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688676ad2cc88322ab6c4b943582b0a8