### PR TITLE
Add debug method to inspect branch fill levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `entity!` now implemented as a procedural macro alongside `pattern!`.
 - Debug helpers `EstimateOverrideConstraint` and `DebugConstraint` moved to a new
   `debug` module.
+- Debug-only `debug_branch_fill` method computes average PATCH branch fill
+  percentages by node size.
+- Added a simple `patch` benchmark filling the tree with fake data and printing
+  branch occupancy averages.
 - `entity!` subsumes the old `entity_inner!` helper; macro invocations can
   optionally provide an existing `TribleSet`.
 - Procedural `namespace!` macro replaces the declarative `NS!` implementation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,10 @@ harness = false
 name = "query"
 harness = false
 
+[[bench]]
+name = "patch"
+harness = false
+
 [profile.bench]
 debug = true
 opt-level = 3

--- a/benches/patch.rs
+++ b/benches/patch.rs
@@ -1,0 +1,27 @@
+use fake::faker::lorem::en::Sentence;
+use fake::Fake;
+use tribles::patch::{Entry, IdentityOrder, SingleSegmentation, PATCH};
+
+fn main() {
+    let mut patch = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+
+    for _ in 0..2_000_000 {
+        let text: String = Sentence(3..8).fake();
+        let mut key = [0u8; 64];
+        let bytes = text.as_bytes();
+        let len = bytes.len().min(64);
+        key[..len].copy_from_slice(&bytes[..len]);
+        let entry = Entry::new(&key);
+        patch.insert(&entry);
+    }
+
+    #[cfg(debug_assertions)]
+    {
+        let avg = patch.debug_branch_fill();
+        println!("Average fill: {:?}", avg);
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        println!("Recompile with debug assertions to compute branch fill");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `debug_branch_fill` on PATCH to compute average occupancy per branch size when compiled in debug mode
- document the new debug helper in the changelog
- add a simple benchmark for calculating branch fill using fake data
- patch benchmark now inserts raw text bytes instead of hashing

## Testing
- `./scripts/devtest.sh`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6887b457297c8322b831952c97480ea4