### PR TITLE
Add ByteTable resize benchmark details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   percentages by node size.
 - Added a simple `patch` benchmark filling the tree with fake data and printing
   branch occupancy averages.
+- Added `byte_table_resize_benchmark` measuring average fill ratios that cause
+  growth for random vs sequential inserts. It now tracks the number of elements
+  inserted at each power-of-two table size to compute per-size and overall
+  averages over many random runs.
+- Preallocated the resize counts vector to avoid repeated allocations during
+  the benchmark.
+- Per-size results now include sizes that never triggered growth so the output
+  has no gaps.
 - `entity!` subsumes the old `entity_inner!` helper; macro invocations can
   optionally provide an existing `TribleSet`.
 - Procedural `namespace!` macro replaces the declarative `NS!` implementation.

--- a/benches/patch.rs
+++ b/benches/patch.rs
@@ -1,8 +1,13 @@
 use fake::faker::lorem::en::Sentence;
 use fake::Fake;
-use tribles::patch::{Entry, IdentityOrder, SingleSegmentation, PATCH};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use tribles::patch::{
+    bytetable::{init as table_init, ByteEntry, ByteTable},
+    Entry, IdentityOrder, SingleSegmentation, PATCH,
+};
 
-fn main() {
+fn patch_fill_benchmark() {
     let mut patch = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
 
     for _ in 0..2_000_000 {
@@ -24,4 +29,100 @@ fn main() {
     {
         println!("Recompile with debug assertions to compute branch fill");
     }
+}
+
+fn byte_table_resize_benchmark() {
+    table_init();
+
+    #[derive(Clone, Debug)]
+    struct Dummy(u8);
+
+    unsafe impl ByteEntry for Dummy {
+        fn key(&self) -> u8 {
+            self.0
+        }
+    }
+
+    fn average_fill(random: bool, runs: usize) -> (f32, Vec<(usize, f32)>) {
+        let mut order: Vec<u8> = (0..=255).collect();
+        // Accumulate the element count before growth for each table size.
+        // We know the table tops out at 256 slots (2^8), so pre-allocate
+        // a slot for each possible power-of-two size to avoid resizing.
+        let mut inserted_totals: Vec<usize> = vec![0; 8];
+
+        for _ in 0..runs {
+            if random {
+                order.shuffle(&mut thread_rng());
+            }
+
+            let mut table: Box<[Option<Dummy>]> = vec![None; 2].into_boxed_slice();
+            let mut size = 2usize;
+            let mut inserted = 0usize;
+
+            for key in order.iter().copied() {
+                let mut entry = Dummy(key);
+                loop {
+                    match table.table_insert(entry) {
+                        None => {
+                            inserted += 1;
+                            break;
+                        }
+                        Some(displaced) => {
+                            let index = usize::ilog2(size) as usize - 1;
+                            inserted_totals[index] += inserted;
+
+                            size *= 2;
+                            let mut grown: Box<[Option<Dummy>]> =
+                                vec![None; size].into_boxed_slice();
+                            table.table_grow(&mut grown);
+                            table = grown;
+                            entry = displaced;
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut by_size = Vec::new();
+        let mut total = 0.0f32;
+        for (index, inserted_total) in inserted_totals.into_iter().enumerate() {
+            let size = 1usize << (index + 1);
+            let avg_inserted = inserted_total as f32 / runs as f32;
+            let ratio = avg_inserted / size as f32;
+            by_size.push((size, ratio));
+            total += ratio;
+        }
+
+        let avg = if !by_size.is_empty() {
+            total / by_size.len() as f32
+        } else {
+            0.0
+        };
+
+        (avg, by_size)
+    }
+
+    const RUNS: usize = 100;
+    let (avg_random, by_size_random) = average_fill(true, RUNS);
+    let (avg_seq, by_size_seq) = average_fill(false, RUNS);
+
+    println!(
+        "ByteTable resize fill - random: {:.3}, sequential: {:.3}",
+        avg_random, avg_seq
+    );
+
+    println!("Per-size fill (random)");
+    for (size, ratio) in by_size_random {
+        println!("  size {:>3}: {:.3}", size, ratio);
+    }
+
+    println!("Per-size fill (sequential)");
+    for (size, ratio) in by_size_seq {
+        println!("  size {:>3}: {:.3}", size, ratio);
+    }
+}
+
+fn main() {
+    patch_fill_benchmark();
+    byte_table_resize_benchmark();
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -9,7 +9,7 @@
 #![allow(unstable_name_collisions)]
 
 mod branch;
-mod bytetable;
+pub mod bytetable;
 mod entry;
 mod leaf;
 
@@ -19,7 +19,7 @@ use branch::*;
 pub use entry::Entry;
 use leaf::*;
 
-use bytetable::*;
+pub use bytetable::*;
 use rand::thread_rng;
 use rand::RngCore;
 use std::cmp::Reverse;


### PR DESCRIPTION
## Summary
- refine `byte_table_resize_benchmark` not to skip any table sizes
- document that the per-size output no longer has gaps

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688a283bff3c8322a60605d78ed29b3a