### PR TITLE
Document cuckoo compression in PATCH chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the benchmark.
 - Per-size results now include sizes that never triggered growth so the output
   has no gaps.
+- Documented PATCH's cuckoo-hashing compression as an alternative to ART-style
+  node compression, explained its compressed-permutation hash with an identity
+  first permutation and a random second permutation and why the smallest and
+  largest nodes are always fully occupied, and included benchmark fill ratios in
+  the book.
+- Annotated the benchmark output to highlight path compression in the size-two
+  case and that the identity hash lets 256-ary nodes store all 256 children.
 - `entity!` subsumes the old `entity_inner!` helper; macro invocations can
   optionally provide an existing `TribleSet`.
 - Procedural `namespace!` macro replaces the declarative `NS!` implementation.

--- a/book/src/deep-dive/patch.md
+++ b/book/src/deep-dive/patch.md
@@ -4,6 +4,56 @@ The **Persistent Adaptive Trie with Cuckoo-compression and Hash-maintenance** (P
 It stores keys in a compressed 256-ary trie where each node uses a byte oriented cuckoo hash table to map to its children.
 This single node layout supports anywhere from two to 256 entries, avoiding the complex branching logic of other adaptive tries.
 
+Traditional Adaptive Radix Trees (ART) employ multiple node variants like
+`Node4`, `Node16` or `Node48` to keep memory usage proportional to the number of
+children. PATCH instead compresses every branch with a byte oriented cuckoo hash
+table. Each node contains two arrays of candidate slots and inserts may displace
+previous entries similar to classic cuckoo hashing. The layout never changes, so
+we avoid the branching logic and pointer chasing common in ART implementations
+while still achieving high occupancy.
+
+Our byte table uses two hash functions built from a specialised *compressed
+permutation*. The first always uses the identity mapping and the second picks a
+random bijective byte→byte permutation. The current table size simply masks off
+the upper bits to compress these results. Doubling the table reveals one more
+significant bit so entries either stay in place or move to bucket `index * 2`.
+When all 256 children exist we disable the random permutation and use the
+identity for both hashes, turning the full table into a simple array where each
+byte already occupies its canonical slot.
+
+The `byte_table_resize_benchmark` demonstrates how densely the table can fill
+before triggering a resize. The benchmark inserts all byte values many times
+and measures the occupancy that forced each power-of-two table size to grow:
+
+```
+ByteTable resize fill - random: 0.744, sequential: 0.840
+Per-size fill (random)
+  size   2: 1.000  # path compression keeps two-entry nodes fully occupied
+  size   4: 0.975
+  size   8: 0.897
+  size  16: 0.841
+  size  32: 0.789
+  size  64: 0.734
+  size 128: 0.713
+  size 256: 0.000  # identity hash maps all 256 children so no resize occurs
+Per-size fill (sequential)
+  size   2: 1.000  # path compression keeps two-entry nodes fully occupied
+  size   4: 1.000
+  size   8: 0.936
+  size  16: 0.990
+  size  32: 0.921
+  size  64: 0.944
+  size 128: 0.926
+  size 256: 0.000  # identity hash maps all 256 children so no resize occurs
+```
+
+Random inserts average roughly 74% table fill while sequential inserts hold
+about 84% before doubling the table size. Nodes of size two are always 100%
+full thanks to path compression, and the final 256‑ary node also reaches 100%
+occupancy because of the linear hash. The benchmark shows `0.000` for the 256
+size as it never triggers a resize. This keeps memory usage predictable without
+the specialized node formats used by ART.
+
 PATCH nodes maintain a rolling hash which allows efficient union, intersection and difference operations over whole subtrees.
 Keys can be viewed in different orders with the [`KeyOrdering`](../../src/patch.rs) trait and segmented via [`KeySegmentation`](../../src/patch.rs) to enable prefix based queries.
 All updates use copy‑on‑write semantics, so cloning a tree is cheap and safe.


### PR DESCRIPTION
## Summary
- describe how PATCH's byte-table compression replaces ART-style node variants
- clarify the compressed-permutation hash uses an identity primary function and a random secondary, falling back to identity for the 256-child case
- show average fill ratios from the new benchmark and annotate the size-2 and size-256 lines to explain their full occupancy

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688a98e563e8832281faaa569bc1c42e