### PR TITLE
Add regular path query support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compressed zero-copy archives are now complete.
 - Incremental queries use a new `pattern_changes!` macro.
 - Added a `matches!` macro mirroring `find!` for boolean checks.
+- Regular path queries via a new `RegularPathConstraint` and namespaced `path!` macro.
+- `path!` automata now store transitions in a `PATCH` for efficient lookups and set operations.
 - Added a `filter` commit selector with a `history_of` helper.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TimeRange` commit selector now delegates to the generic `filter` selector.
 - Removed the `Completed Work` section from `INVENTORY.md`; finished tasks are
   now tracked in this changelog.
+- Canonicalized epsilon closures in regular path queries and documented the
+  Thompson-style automaton construction.
 
 ### Fixed
 - Enforce `PREFIX_LEN <= KEY_LEN` for prefix checks in PATCH.

--- a/book/src/query-language.md
+++ b/book/src/query-language.md
@@ -79,3 +79,33 @@ Every building block implements the
 [`Constraint`](crate::query::Constraint) trait.  You can implement this trait on
 your own types to integrate custom data sources or query operators with the
 solver.
+
+## Regular path queries
+
+The `path!` macro lets you search for graph paths matching a regular
+expression over edge attributes.  It expands to a
+[`RegularPathConstraint`](crate::query::RegularPathConstraint) and can be
+combined with other constraints.  Invoke it through a namespace module
+(`social::path!`) to implicitly resolve attribute names:
+
+```rust
+use tribles::prelude::*;
+NS! { namespace social {
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" as follows: GenId;
+    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" as likes: GenId;
+} }
+let mut kb = TribleSet::new();
+let a = fucid(); let b = fucid(); let c = fucid();
+kb += social::entity!(&a, { follows: &b });
+kb += social::entity!(&b, { likes: &c });
+
+let results: Vec<_> = find!((s: Value<_>, e: Value<_>),
+    social::path!(&kb, s (follows | likes)+ e)).collect();
+```
+
+The middle section uses a familiar regex syntax to describe allowed edge
+sequences.  Editors with Rust macro expansion support provide highlighting and
+validation of the regular expression at compile time. Paths reference
+attributes from a single namespace; to traverse edges across multiple
+namespaces, create a new namespace that re-exports the desired attributes and
+invoke `path!` through it.

--- a/examples/path.rs
+++ b/examples/path.rs
@@ -1,0 +1,24 @@
+use tribles::prelude::*;
+use tribles::value::schemas::genid::GenId;
+
+NS! {
+    namespace social {
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" as follows: GenId;
+        "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" as likes: GenId;
+    }
+}
+
+fn main() {
+    let mut kb = TribleSet::new();
+    let a = fucid();
+    let b = fucid();
+    let c = fucid();
+    kb += social::entity!(&a, { follows: &b });
+    kb += social::entity!(&b, { likes: &c });
+
+    for (s, e) in
+        find!((s: Value<_>, e: Value<_>), social::path!(kb.clone(), s (follows | likes)+ e))
+    {
+        println!("{:?} -> {:?}", s, e);
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -99,6 +99,7 @@ pub mod hashsetconstraint;
 pub mod intersectionconstraint;
 pub mod mask;
 pub mod patchconstraint;
+pub mod regularpathconstraint;
 pub mod unionconstraint;
 mod variableset;
 
@@ -113,6 +114,7 @@ use mask::*;
 
 use crate::value::{schemas::genid::GenId, RawValue, Value, ValueSchema};
 
+pub use regularpathconstraint::{PathOp, RegularPathConstraint};
 pub use variableset::VariableSet;
 
 /// Types storing tribles can implement this trait to expose them to queries.

--- a/src/query/regularpathconstraint.rs
+++ b/src/query/regularpathconstraint.rs
@@ -1,0 +1,288 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::id::{id_from_value, id_into_value, RawId, ID_LEN};
+use crate::patch::{Entry, IdentityOrder, SingleSegmentation, PATCH};
+use crate::query::{Binding, Constraint, Variable, VariableId, VariableSet};
+use crate::trible::TribleSet;
+use crate::trible::{A_END, A_START, E_END, E_START, V_START};
+use crate::value::schemas::genid::GenId;
+use crate::value::RawValue;
+
+#[derive(Clone)]
+pub enum PathOp {
+    Attr(RawId),
+    Concat,
+    Union,
+    Star,
+    Plus,
+}
+
+const STATE_LEN: usize = core::mem::size_of::<u64>();
+const EDGE_KEY_LEN: usize = STATE_LEN * 2 + ID_LEN;
+const NIL_ID: RawId = [0; ID_LEN];
+
+#[derive(Clone)]
+struct Automaton {
+    transitions: PATCH<EDGE_KEY_LEN, IdentityOrder, SingleSegmentation>,
+    start: u64,
+    accept: u64,
+}
+
+impl Automaton {
+    fn new(ops: &[PathOp]) -> Self {
+        #[derive(Clone)]
+        struct Frag {
+            start: u64,
+            accept: u64,
+        }
+
+        fn new_state(counter: &mut u64) -> u64 {
+            let id = *counter;
+            *counter += 1;
+            id
+        }
+
+        fn insert_edge(
+            patch: &mut PATCH<EDGE_KEY_LEN, IdentityOrder, SingleSegmentation>,
+            from: &u64,
+            label: &RawId,
+            to: &u64,
+        ) {
+            let mut key = [0u8; EDGE_KEY_LEN];
+            key[..STATE_LEN].copy_from_slice(&from.to_be_bytes());
+            key[STATE_LEN..STATE_LEN + ID_LEN].copy_from_slice(label);
+            key[STATE_LEN + ID_LEN..].copy_from_slice(&to.to_be_bytes());
+            patch.insert(&Entry::new(&key));
+        }
+
+        let mut trans = PATCH::<EDGE_KEY_LEN, IdentityOrder, SingleSegmentation>::new();
+        let mut counter: u64 = 0;
+        let mut stack: Vec<Frag> = Vec::new();
+
+        for op in ops {
+            match op {
+                PathOp::Attr(id) => {
+                    let s = new_state(&mut counter);
+                    let e = new_state(&mut counter);
+                    insert_edge(&mut trans, &s, id, &e);
+                    stack.push(Frag {
+                        start: s,
+                        accept: e,
+                    });
+                }
+                PathOp::Concat => {
+                    let b = stack.pop().unwrap();
+                    let a = stack.pop().unwrap();
+                    insert_edge(&mut trans, &a.accept, &NIL_ID, &b.start);
+                    stack.push(Frag {
+                        start: a.start,
+                        accept: b.accept,
+                    });
+                }
+                PathOp::Union => {
+                    let b = stack.pop().unwrap();
+                    let a = stack.pop().unwrap();
+                    let s = new_state(&mut counter);
+                    let e = new_state(&mut counter);
+                    insert_edge(&mut trans, &s, &NIL_ID, &a.start);
+                    insert_edge(&mut trans, &s, &NIL_ID, &b.start);
+                    insert_edge(&mut trans, &a.accept, &NIL_ID, &e);
+                    insert_edge(&mut trans, &b.accept, &NIL_ID, &e);
+                    stack.push(Frag {
+                        start: s,
+                        accept: e,
+                    });
+                }
+                PathOp::Star => {
+                    let a = stack.pop().unwrap();
+                    let s = new_state(&mut counter);
+                    let e = new_state(&mut counter);
+                    insert_edge(&mut trans, &s, &NIL_ID, &a.start);
+                    insert_edge(&mut trans, &s, &NIL_ID, &e);
+                    insert_edge(&mut trans, &a.accept, &NIL_ID, &a.start);
+                    insert_edge(&mut trans, &a.accept, &NIL_ID, &e);
+                    stack.push(Frag {
+                        start: s,
+                        accept: e,
+                    });
+                }
+                PathOp::Plus => {
+                    let a = stack.pop().unwrap();
+                    let s = new_state(&mut counter);
+                    let e = new_state(&mut counter);
+                    insert_edge(&mut trans, &s, &NIL_ID, &a.start);
+                    insert_edge(&mut trans, &a.accept, &NIL_ID, &a.start);
+                    insert_edge(&mut trans, &a.accept, &NIL_ID, &e);
+                    stack.push(Frag {
+                        start: s,
+                        accept: e,
+                    });
+                }
+            }
+        }
+
+        let frag = stack.pop().unwrap();
+        Automaton {
+            transitions: trans,
+            start: frag.start,
+            accept: frag.accept,
+        }
+    }
+
+    fn transitions_from(&self, state: &u64, label: &RawId) -> Vec<u64> {
+        let mut prefix = [0u8; STATE_LEN + ID_LEN];
+        prefix[..STATE_LEN].copy_from_slice(&state.to_be_bytes());
+        prefix[STATE_LEN..].copy_from_slice(label);
+        let mut dests = Vec::new();
+        self.transitions
+            .infixes::<{ STATE_LEN + ID_LEN }, { STATE_LEN }, _>(&prefix, |to| {
+                dests.push(u64::from_be_bytes(*to));
+            });
+        dests
+    }
+
+    fn epsilon_closure(&self, states: Vec<u64>) -> Vec<u64> {
+        let mut result = states.clone();
+        let mut stack = states;
+        while let Some(s) = stack.pop() {
+            for dest in self.transitions_from(&s, &NIL_ID) {
+                if !result.contains(&dest) {
+                    result.push(dest);
+                    stack.push(dest);
+                }
+            }
+        }
+        result
+    }
+}
+
+pub struct RegularPathConstraint {
+    start: VariableId,
+    end: VariableId,
+    automaton: Automaton,
+    edges: HashMap<RawId, Vec<(RawId, RawId)>>,
+    nodes: Vec<RawValue>,
+}
+
+impl RegularPathConstraint {
+    pub fn new(
+        set: TribleSet,
+        start: Variable<GenId>,
+        end: Variable<GenId>,
+        ops: &[PathOp],
+    ) -> Self {
+        let automaton = Automaton::new(ops);
+        let mut edges: HashMap<RawId, Vec<(RawId, RawId)>> = HashMap::new();
+        let mut node_set: HashSet<RawId> = HashSet::new();
+        for t in set.iter() {
+            let e: RawId = t.data[E_START..=E_END].try_into().unwrap();
+            let a: RawId = t.data[A_START..=A_END].try_into().unwrap();
+            let v = &t.data[V_START..(V_START + 32)];
+            if v[0..16] == [0; 16] {
+                let dest: RawId = v[16..32].try_into().unwrap();
+                edges.entry(e).or_default().push((a, dest));
+                node_set.insert(e);
+                node_set.insert(dest);
+            }
+        }
+        let nodes: Vec<RawValue> = node_set.iter().map(|id| id_into_value(id)).collect();
+        RegularPathConstraint {
+            start: start.index,
+            end: end.index,
+            automaton,
+            edges,
+            nodes,
+        }
+    }
+
+    fn has_path(&self, from: &RawId, to: &RawId) -> bool {
+        let start_states = self.automaton.epsilon_closure(vec![self.automaton.start]);
+        let mut queue: VecDeque<(RawId, Vec<u64>)> = VecDeque::new();
+        queue.push_back((*from, start_states.clone()));
+        let mut visited: HashSet<(RawId, Vec<u64>)> = HashSet::new();
+        visited.insert((*from, {
+            let mut s = start_states.clone();
+            s.sort();
+            s
+        }));
+        while let Some((node, states)) = queue.pop_front() {
+            let mut sorted = states.clone();
+            sorted.sort();
+            if sorted.contains(&self.automaton.accept) && node == *to {
+                return true;
+            }
+            if let Some(edges) = self.edges.get(&node) {
+                for (attr, dest) in edges {
+                    let mut next_states = Vec::new();
+                    for s in &states {
+                        next_states.extend(self.automaton.transitions_from(s, attr));
+                    }
+                    if next_states.is_empty() {
+                        continue;
+                    }
+                    let mut closure = self.automaton.epsilon_closure(next_states);
+                    closure.sort();
+                    if visited.insert((*dest, closure.clone())) {
+                        queue.push_back((*dest, closure));
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
+impl<'a> Constraint<'a> for RegularPathConstraint {
+    fn variables(&self) -> VariableSet {
+        let mut vars = VariableSet::new_empty();
+        vars.set(self.start);
+        vars.set(self.end);
+        vars
+    }
+
+    fn estimate(&self, variable: VariableId, _binding: &Binding) -> Option<usize> {
+        if variable == self.start || variable == self.end {
+            Some(self.nodes.len())
+        } else {
+            None
+        }
+    }
+
+    fn propose(&self, variable: VariableId, _binding: &Binding, proposals: &mut Vec<RawValue>) {
+        if variable == self.start || variable == self.end {
+            proposals.extend(self.nodes.iter().cloned());
+        }
+    }
+
+    fn confirm(&self, variable: VariableId, binding: &Binding, proposals: &mut Vec<RawValue>) {
+        if variable == self.start {
+            if let Some(end_val) = binding.get(self.end) {
+                if let Some(end_id) = id_from_value(end_val) {
+                    proposals.retain(|v| {
+                        if let Some(start_id) = id_from_value(v) {
+                            self.has_path(&start_id, &end_id)
+                        } else {
+                            false
+                        }
+                    });
+                } else {
+                    proposals.clear();
+                }
+            }
+        } else if variable == self.end {
+            if let Some(start_val) = binding.get(self.start) {
+                if let Some(start_id) = id_from_value(start_val) {
+                    proposals.retain(|v| {
+                        if let Some(end_id) = id_from_value(v) {
+                            self.has_path(&start_id, &end_id)
+                        } else {
+                            false
+                        }
+                    });
+                } else {
+                    proposals.clear();
+                }
+            }
+        }
+    }
+}

--- a/tests/regular_path_constraint.rs
+++ b/tests/regular_path_constraint.rs
@@ -1,0 +1,58 @@
+use tribles::prelude::*;
+use tribles::value::schemas::genid::GenId;
+
+NS! {
+    namespace social {
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" as follows: GenId;
+        "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" as likes: GenId;
+    }
+}
+
+#[test]
+fn simple_path() {
+    let mut kb = TribleSet::new();
+    let a = fucid();
+    let b = fucid();
+    kb += social::entity!(&a, { follows: &b });
+    let a_val = a.to_value();
+    let b_val = b.to_value();
+    let results: Vec<_> =
+        find!((s: Value<_>, e: Value<_>), social::path!(kb.clone(), s follows e)).collect();
+    assert!(results.contains(&(a_val, b_val)));
+}
+
+#[test]
+fn alternation() {
+    let mut kb = TribleSet::new();
+    let a = fucid();
+    let b = fucid();
+    let c = fucid();
+    kb += social::entity!(&a, { follows: &b });
+    kb += social::entity!(&a, { likes: &c });
+    let a_val = a.to_value();
+    let b_val = b.to_value();
+    let c_val = c.to_value();
+
+    let results: Vec<_> =
+        find!((s: Value<_>, e: Value<_>), social::path!(kb.clone(), s (follows | likes) e))
+            .collect();
+    assert!(results.contains(&(a_val, b_val)));
+    assert!(results.contains(&(a_val, c_val)));
+}
+
+#[test]
+fn repetition() {
+    let mut kb = TribleSet::new();
+    let a = fucid();
+    let b = fucid();
+    let c = fucid();
+    kb += social::entity!(&a, { follows: &b });
+    kb += social::entity!(&b, { follows: &c });
+
+    let start_val = a.to_value();
+    let end_val = c.to_value();
+    let results: Vec<_> = find!((s: Value<_>, e: Value<_>),
+        and!(s.is(start_val), e.is(end_val), social::path!(kb.clone(), s follows+ e)))
+    .collect();
+    assert!(results.contains(&(start_val, end_val)));
+}

--- a/tribles-macros/src/lib.rs
+++ b/tribles-macros/src/lib.rs
@@ -29,7 +29,7 @@
 //! directly outside of the `tribles` codebase.
 
 use proc_macro::TokenStream;
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::{Delimiter, Span, TokenStream as TokenStream2, TokenTree};
 use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::{braced, bracketed, parenthesized, Token};
@@ -43,6 +43,219 @@ pub fn namespace(input: TokenStream) -> TokenStream {
         Ok(ts) => ts,
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+#[proc_macro]
+pub fn path(input: TokenStream) -> TokenStream {
+    match path_impl(input) {
+        Ok(ts) => ts,
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+struct PathInput {
+    crate_path: Path,
+    ns: Path,
+    set: Expr,
+    rest: TokenStream2,
+}
+
+impl Parse for PathInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let crate_path: Path = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let ns: Path = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let set: Expr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let rest: TokenStream2 = input.parse()?;
+        Ok(PathInput {
+            crate_path,
+            ns,
+            set,
+            rest,
+        })
+    }
+}
+
+fn path_impl(input: TokenStream) -> syn::Result<TokenStream> {
+    let PathInput {
+        crate_path,
+        ns,
+        set,
+        rest,
+    } = syn::parse(input)?;
+    let tokens: Vec<TokenTree> = rest.into_iter().collect();
+    if tokens.len() < 2 {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            "expected start, regex, end",
+        ));
+    }
+    let start = match &tokens[0] {
+        TokenTree::Ident(id) => id.clone(),
+        _ => {
+            return Err(syn::Error::new(
+                tokens[0].span(),
+                "expected start identifier",
+            ))
+        }
+    };
+    let end = match &tokens[tokens.len() - 1] {
+        TokenTree::Ident(id) => id.clone(),
+        _ => {
+            return Err(syn::Error::new(
+                tokens[tokens.len() - 1].span(),
+                "expected end identifier",
+            ))
+        }
+    };
+    let regex_tokens = &tokens[1..tokens.len() - 1];
+
+    #[derive(Clone)]
+    enum Tok {
+        Sym(Ident),
+        Or,
+        Star,
+        Plus,
+        LParen,
+        RParen,
+    }
+
+    fn lex(ts: &[TokenTree]) -> syn::Result<Vec<Tok>> {
+        let mut out = Vec::new();
+        let mut i = 0usize;
+        while i < ts.len() {
+            match &ts[i] {
+                TokenTree::Ident(id) => {
+                    out.push(Tok::Sym(id.clone()));
+                    i += 1;
+                }
+                TokenTree::Punct(p) if p.as_char() == '|' => {
+                    out.push(Tok::Or);
+                    i += 1;
+                }
+                TokenTree::Punct(p) if p.as_char() == '*' => {
+                    out.push(Tok::Star);
+                    i += 1;
+                }
+                TokenTree::Punct(p) if p.as_char() == '+' => {
+                    out.push(Tok::Plus);
+                    i += 1;
+                }
+                TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => {
+                    i += 1;
+                    out.push(Tok::LParen);
+                    out.extend(lex(&g.stream().into_iter().collect::<Vec<_>>())?);
+                    out.push(Tok::RParen);
+                }
+                t => return Err(syn::Error::new(t.span(), "unexpected token in regex")),
+            }
+        }
+        Ok(out)
+    }
+
+    let lexed = lex(regex_tokens)?;
+
+    fn needs_concat(a: &Tok, b: &Tok) -> bool {
+        matches!(a, Tok::Sym(_) | Tok::RParen | Tok::Star | Tok::Plus)
+            && matches!(b, Tok::Sym(_) | Tok::LParen)
+    }
+
+    #[derive(Clone)]
+    enum OpTok {
+        Sym(Ident),
+        Or,
+        Concat,
+        Star,
+        Plus,
+        LParen,
+        RParen,
+    }
+
+    let mut infix = Vec::new();
+    for i in 0..lexed.len() {
+        match &lexed[i] {
+            Tok::Sym(p) => infix.push(OpTok::Sym(p.clone())),
+            Tok::Or => infix.push(OpTok::Or),
+            Tok::Star => infix.push(OpTok::Star),
+            Tok::Plus => infix.push(OpTok::Plus),
+            Tok::LParen => infix.push(OpTok::LParen),
+            Tok::RParen => infix.push(OpTok::RParen),
+        }
+        if i + 1 < lexed.len() && needs_concat(&lexed[i], &lexed[i + 1]) {
+            infix.push(OpTok::Concat);
+        }
+    }
+
+    fn prec(t: &OpTok) -> u8 {
+        match t {
+            OpTok::Star | OpTok::Plus => 3,
+            OpTok::Concat => 2,
+            OpTok::Or => 1,
+            _ => 0,
+        }
+    }
+    fn right_assoc(t: &OpTok) -> bool {
+        matches!(t, OpTok::Star | OpTok::Plus)
+    }
+
+    let mut output = Vec::<OpTok>::new();
+    let mut stack = Vec::<OpTok>::new();
+    for token in infix {
+        match token {
+            OpTok::Sym(_) => output.push(token),
+            OpTok::LParen => stack.push(OpTok::LParen),
+            OpTok::RParen => {
+                while let Some(op) = stack.pop() {
+                    if matches!(op, OpTok::LParen) {
+                        break;
+                    } else {
+                        output.push(op);
+                    }
+                }
+            }
+            OpTok::Or | OpTok::Concat | OpTok::Star | OpTok::Plus => {
+                while let Some(op) = stack.last() {
+                    if matches!(op, OpTok::LParen) {
+                        break;
+                    }
+                    if prec(op) > prec(&token) || (!right_assoc(&token) && prec(op) == prec(&token))
+                    {
+                        output.push(stack.pop().unwrap());
+                    } else {
+                        break;
+                    }
+                }
+                stack.push(token);
+            }
+        }
+    }
+    while let Some(op) = stack.pop() {
+        output.push(op);
+    }
+
+    let ops: Vec<TokenStream2> = output
+        .into_iter()
+        .map(|t| match t {
+            OpTok::Sym(ident) => {
+                quote! { PathOp::Attr(#crate_path::id::RawId::from(#ns::ids::#ident)) }
+            }
+            OpTok::Or => quote! { PathOp::Union },
+            OpTok::Concat => quote! { PathOp::Concat },
+            OpTok::Star => quote! { PathOp::Star },
+            OpTok::Plus => quote! { PathOp::Plus },
+            _ => panic!(),
+        })
+        .collect();
+
+    let output = quote! {
+        {
+            use #crate_path::query::regularpathconstraint::{RegularPathConstraint, PathOp};
+            RegularPathConstraint::new(#set.clone(), #start, #end, &[#(#ops),*])
+        }
+    };
+    Ok(output.into())
 }
 
 /// Parsed input for the [`pattern`] macro.

--- a/tribles-macros/src/namespace.rs
+++ b/tribles-macros/src/namespace.rs
@@ -128,6 +128,15 @@ pub(crate) fn namespace_impl(input: TokenStream) -> syn::Result<TokenStream> {
         }
     };
 
+    let path_macro = quote! {
+        #[macro_pub::macro_pub]
+        macro_rules! path {
+            ($set:expr, $($rest:tt)*) => {{
+                ::tribles_macros::path!(::tribles, #mod_name, $set, $($rest)*)
+            }};
+        }
+    };
+
     let output = quote! {
         #(#attrs)*
         #vis mod #mod_name {
@@ -154,6 +163,7 @@ pub(crate) fn namespace_impl(input: TokenStream) -> syn::Result<TokenStream> {
             #entity_macro
             #pattern_macro
             #pattern_changes_macro
+            #path_macro
         }
     };
 


### PR DESCRIPTION
## Summary
- support regex-based graph traversal with `RegularPathConstraint`
- introduce `path!` macro for compiling edge regexes into constraints
- document and demonstrate regular path queries
- generate namespaced `path!` wrappers for automatic attribute resolution
- require `path!` attributes to come from the invoked namespace
- store `path!` automata transitions in a `PATCH` for faster set operations
- represent automaton states as compact `u64` identifiers

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688c712957f88322a88796de47e169eb