### PR TITLE
Refactor regular path engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Workspace::checkout` helper to load commit contents.
 - `pattern!` now implemented as a procedural macro in the new `tribles-macros` crate.
 - `entity!` now implemented as a procedural macro alongside `pattern!`.
+- `ThompsonEngine` implementing a new `PathEngine` trait for regular path queries,
+  and `RegularPathConstraint` is now generic over `PathEngine`.
 - Debug helpers `EstimateOverrideConstraint` and `DebugConstraint` moved to a new
   `debug` module.
 - Debug-only `debug_branch_fill` method computes average PATCH branch fill

--- a/src/query.rs
+++ b/src/query.rs
@@ -114,7 +114,7 @@ use mask::*;
 
 use crate::value::{schemas::genid::GenId, RawValue, Value, ValueSchema};
 
-pub use regularpathconstraint::{PathOp, RegularPathConstraint};
+pub use regularpathconstraint::{PathEngine, PathOp, RegularPathConstraint, ThompsonEngine};
 pub use variableset::VariableSet;
 
 /// Types storing tribles can implement this trait to expose them to queries.

--- a/tribles-macros/src/lib.rs
+++ b/tribles-macros/src/lib.rs
@@ -251,8 +251,8 @@ fn path_impl(input: TokenStream) -> syn::Result<TokenStream> {
 
     let output = quote! {
         {
-            use #crate_path::query::regularpathconstraint::{RegularPathConstraint, PathOp};
-            RegularPathConstraint::new(#set.clone(), #start, #end, &[#(#ops),*])
+            use #crate_path::query::regularpathconstraint::{PathOp, RegularPathConstraint, ThompsonEngine};
+            RegularPathConstraint::<ThompsonEngine>::new(#set.clone(), #start, #end, &[#(#ops),*])
         }
     };
     Ok(output.into())


### PR DESCRIPTION
## Summary
- extract ThompsonEngine to build and traverse NFAs for path queries
- introduce PathEngine trait and make RegularPathConstraint generic over it
- update macros and re-exports for new engine

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d2d33682c8322b7856d403b728aa0