### PR TITLE
Generate trible key layout from declarative segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   percentages by node size.
 - Added a simple `patch` benchmark filling the tree with fake data and printing
   branch occupancy averages.
+- Trible key segmentation and ordering tables are now generated from a
+  declarative segment layout, simplifying maintenance.
 - Added `byte_table_resize_benchmark` measuring average fill ratios that cause
   growth for random vs sequential inserts. It now tracks the number of elements
   inserted at each power-of-two table size to compute per-size and overall

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -24,6 +24,8 @@
 - Implement a garbage collection mechanism that scans branch and commit
   archives without fully deserialising them to find reachable blob handles.
   Anything not discovered this way can be forgotten by the underlying store.
+- Generalise the declarative key description utilities to other key types so
+  segment layouts and orderings can be defined once and generated automatically.
 
 ## Additional Built-in Schemas
 The existing collection of schemas covers the basics like strings, large


### PR DESCRIPTION
## Summary
- derive trible key segmentation and ordering tables from a declarative segment layout
- document the change in the changelog and inventory

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688f7260a5848322ab8c84001aa5ef28