### PR TITLE
Use associated consts for key layout tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   percentages by node size.
 - Added a simple `patch` benchmark filling the tree with fake data and printing
   branch occupancy averages.
+- Trible key segmentation and ordering tables are now generated from a
+  declarative segment layout, simplifying maintenance.
+- PATCH exposes const helpers to derive segment maps and ordering
+  permutations from a declarative key layout.
+- Introduced `key_segmentation!` and `key_ordering!` macros to emit
+  `KeySegmentation` and `KeyOrdering` implementations from those declarative
+  layouts.
 - Added `byte_table_resize_benchmark` measuring average fill ratios that cause
   growth for random vs sequential inserts. It now tracks the number of elements
   inserted at each power-of-two table size to compute per-size and overall
@@ -51,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded the repository example to store actual data and simplified the conflict loop.
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 ### Changed
+- `KeyOrdering` and `KeySegmentation` now expose translation tables as associated const arrays instead of methods.
+- Removed `key_index`, `tree_index`, and `segment` helper methods in favor of direct const-table lookups and tied `KeyOrdering` to its `KeySegmentation` with an explicit segment permutation.
+- `KeyOrdering` now declares its `KeySegmentation` via an associated type instead of a separate generic parameter.
 - `ByteTable` plans insertions by recursively seeking a free slot and shifts entries only after a path is found, returning the entry on failure so callers can grow the table.
 - ByteTable's planner tracks visited keys with a stack-allocated bitset to avoid heap allocations.
 - Simplified the planner and table helpers for clearer ByteTable insertion code.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -24,6 +24,11 @@
 - Implement a garbage collection mechanism that scans branch and commit
   archives without fully deserialising them to find reachable blob handles.
   Anything not discovered this way can be forgotten by the underlying store.
+- Generalise the declarative key description utilities to other key types so
+  segment layouts and orderings can be defined once and generated automatically.
+- Provide a macro to declare key layouts that emits segmentation and
+  ordering implementations for PATCH at compile time.
+- Expose segment iterators on PATCH using `KeyOrdering`'s segment permutation instead of raw key ranges.
 
 ## Additional Built-in Schemas
 The existing collection of schemas covers the basics like strings, large

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -16,8 +16,7 @@ use tribles::prelude::blobschemas::*;
 use tribles::prelude::valueschemas::*;
 use tribles::prelude::*;
 
-use tribles::patch::{Entry, IdentityOrder};
-use tribles::patch::{SingleSegmentation, PATCH};
+use tribles::patch::{Entry, IdentityOrder, PATCH};
 
 use im::OrdSet;
 
@@ -114,7 +113,7 @@ fn patch_benchmark(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("put", i), i, |b, &i| {
             let samples = random_tribles(i as usize);
             b.iter(|| {
-                let mut patch = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+                let mut patch = PATCH::<64, IdentityOrder>::new();
                 for t in black_box(&samples) {
                     let entry: Entry<64> = Entry::new(&t.data);
                     patch.insert(&entry);
@@ -124,7 +123,7 @@ fn patch_benchmark(c: &mut Criterion) {
         });
         group.bench_with_input(BenchmarkId::new("iter", i), i, |b, &i| {
             let samples = random_tribles(i as usize);
-            let mut patch = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut patch = PATCH::<64, IdentityOrder>::new();
             for t in black_box(&samples) {
                 let entry: Entry<64> = Entry::new(&t.data);
                 patch.insert(&entry);
@@ -133,7 +132,7 @@ fn patch_benchmark(c: &mut Criterion) {
         });
         group.bench_with_input(BenchmarkId::new("infixes", i), i, |b, &i| {
             let samples = random_tribles(i as usize);
-            let mut patch = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut patch = PATCH::<64, IdentityOrder>::new();
             for t in black_box(&samples) {
                 let entry: Entry<64> = Entry::new(&t.data);
                 patch.insert(&entry);
@@ -154,8 +153,7 @@ fn patch_benchmark(c: &mut Criterion) {
             let patchs: Vec<_> = samples
                 .chunks(total_unioned / i)
                 .map(|samples| {
-                    let mut patch: PATCH<64, IdentityOrder, SingleSegmentation> =
-                        PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+                    let mut patch: PATCH<64, IdentityOrder> = PATCH::<64, IdentityOrder>::new();
                     for t in samples {
                         let entry: Entry<64> = Entry::new(&t.data);
                         patch.insert(&entry);
@@ -164,13 +162,12 @@ fn patch_benchmark(c: &mut Criterion) {
                 })
                 .collect();
             b.iter(|| {
-                black_box(&patchs).iter().fold(
-                    PATCH::<64, IdentityOrder, SingleSegmentation>::new(),
-                    |mut a, p| {
+                black_box(&patchs)
+                    .iter()
+                    .fold(PATCH::<64, IdentityOrder>::new(), |mut a, p| {
                         a.union(p.clone());
                         a
-                    },
-                )
+                    })
             });
         });
     }

--- a/benches/patch.rs
+++ b/benches/patch.rs
@@ -4,11 +4,11 @@ use rand::seq::SliceRandom;
 use rand::thread_rng;
 use tribles::patch::{
     bytetable::{init as table_init, ByteEntry, ByteTable},
-    Entry, IdentityOrder, SingleSegmentation, PATCH,
+    Entry, IdentityOrder, PATCH,
 };
 
 fn patch_fill_benchmark() {
-    let mut patch = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+    let mut patch = PATCH::<64, IdentityOrder>::new();
 
     for _ in 0..2_000_000 {
         let text: String = Sentence(3..8).fake();

--- a/benches/query.rs
+++ b/benches/query.rs
@@ -16,8 +16,7 @@ use tribles::prelude::blobschemas::*;
 use tribles::prelude::valueschemas::*;
 use tribles::prelude::*;
 
-use tribles::patch::{Entry, IdentityOrder};
-use tribles::patch::{SingleSegmentation, PATCH};
+use tribles::patch::{Entry, IdentityOrder, PATCH};
 
 use im::OrdSet;
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -23,7 +23,7 @@ pub use rngid::rngid;
 pub use ufoid::ufoid;
 
 use crate::{
-    patch::{Entry, IdentityOrder, SingleSegmentation, PATCH},
+    patch::{Entry, IdentityOrder, PATCH},
     prelude::valueschemas::GenId,
     query::{Constraint, ContainsConstraint, Variable},
     value::{RawValue, VALUE_LEN},
@@ -375,7 +375,7 @@ pub fn local_ids(v: Variable<GenId>) -> impl Constraint<'static> {
 /// ```
 ///
 pub struct IdOwner {
-    owned_ids: RefCell<PATCH<ID_LEN, IdentityOrder, SingleSegmentation>>,
+    owned_ids: RefCell<PATCH<ID_LEN, IdentityOrder>>,
 }
 
 /// An `ExclusiveId` that is associated with an `IdOwner`.
@@ -586,10 +586,8 @@ impl<'a> Drop for OwnedId<'a> {
 }
 
 impl ContainsConstraint<'static, GenId> for &IdOwner {
-    type Constraint = <PATCH<ID_LEN, IdentityOrder, SingleSegmentation> as ContainsConstraint<
-        'static,
-        GenId,
-    >>::Constraint;
+    type Constraint =
+        <PATCH<ID_LEN, IdentityOrder> as ContainsConstraint<'static, GenId>>::Constraint;
 
     fn has(self, v: Variable<GenId>) -> Self::Constraint {
         self.owned_ids.borrow().clone().has(v)

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -50,26 +50,149 @@ fn init_sip_key() {
     });
 }
 
+/// Builds a per-byte segment map from the segment lengths.
+///
+/// The returned table maps each key byte to its segment index.
+pub const fn build_segmentation<const N: usize, const M: usize>(lens: [usize; M]) -> [usize; N] {
+    let mut res = [0; N];
+    let mut seg = 0;
+    let mut off = 0;
+    while seg < M {
+        let len = lens[seg];
+        let mut i = 0;
+        while i < len {
+            res[off + i] = seg;
+            i += 1;
+        }
+        off += len;
+        seg += 1;
+    }
+    res
+}
+
+/// Builds an identity permutation table of length `N`.
+pub const fn identity_map<const N: usize>() -> [usize; N] {
+    let mut res = [0; N];
+    let mut i = 0;
+    while i < N {
+        res[i] = i;
+        i += 1;
+    }
+    res
+}
+
+/// Builds a table translating indices from key order to tree order.
+///
+/// `lens` describes the segment lengths in key order and `perm` is the
+/// permutation of those segments in tree order.
+pub const fn build_key_to_tree<const N: usize, const M: usize>(
+    lens: [usize; M],
+    perm: [usize; M],
+) -> [usize; N] {
+    let mut key_starts = [0; M];
+    let mut off = 0;
+    let mut i = 0;
+    while i < M {
+        key_starts[i] = off;
+        off += lens[i];
+        i += 1;
+    }
+
+    let mut tree_starts = [0; M];
+    off = 0;
+    i = 0;
+    while i < M {
+        let seg = perm[i];
+        tree_starts[seg] = off;
+        off += lens[seg];
+        i += 1;
+    }
+
+    let mut res = [0; N];
+    let mut seg = 0;
+    while seg < M {
+        let len = lens[seg];
+        let ks = key_starts[seg];
+        let ts = tree_starts[seg];
+        let mut j = 0;
+        while j < len {
+            res[ks + j] = ts + j;
+            j += 1;
+        }
+        seg += 1;
+    }
+    res
+}
+
+/// Inverts a permutation table.
+pub const fn invert<const N: usize>(arr: [usize; N]) -> [usize; N] {
+    let mut res = [0; N];
+    let mut i = 0;
+    while i < N {
+        res[arr[i]] = i;
+        i += 1;
+    }
+    res
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! key_segmentation {
+    (@count $($e:expr),* $(,)?) => {
+        <[()]>::len(&[$($crate::key_segmentation!(@sub $e)),*])
+    };
+    (@sub $e:expr) => { () };
+    ($name:ident, $len:expr, [$($seg_len:expr),+ $(,)?]) => {
+        #[derive(Copy, Clone, Debug)]
+        pub struct $name;
+        impl $name {
+            pub const SEG_LENS: [usize; $crate::key_segmentation!(@count $($seg_len),*)] = [$($seg_len),*];
+        }
+        impl $crate::patch::KeySegmentation<$len> for $name {
+            const SEGMENTS: [usize; $len] = $crate::patch::build_segmentation::<$len, {$crate::key_segmentation!(@count $($seg_len),*)}>(Self::SEG_LENS);
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! key_ordering {
+    (@count $($e:expr),* $(,)?) => {
+        <[()]>::len(&[$($crate::key_ordering!(@sub $e)),*])
+    };
+    (@sub $e:expr) => { () };
+    ($name:ident, $seg:ty, $len:expr, [$($perm:expr),+ $(,)?]) => {
+        #[derive(Copy, Clone, Debug)]
+        pub struct $name;
+        impl $crate::patch::KeyOrdering<$len> for $name {
+            type Segmentation = $seg;
+            const SEGMENT_PERM: &'static [usize] = &[$($perm),*];
+            const KEY_TO_TREE: [usize; $len] = $crate::patch::build_key_to_tree::<$len, {$crate::key_ordering!(@count $($perm),*)}>(<$seg>::SEG_LENS, [$($perm),*]);
+            const TREE_TO_KEY: [usize; $len] = $crate::patch::invert(Self::KEY_TO_TREE);
+        }
+    };
+}
+
 /// A trait is used to provide a re-ordered view of the keys stored in the PATCH.
 /// This allows for different PATCH instances share the same leaf nodes,
 /// independent of the key ordering used in the tree.
 pub trait KeyOrdering<const KEY_LEN: usize>: Copy + Clone + Debug {
-    /// Returns the index in the tree view, given the index in the key view.
-    ///
-    /// This is the inverse of [Self::key_index].
-    fn tree_index(key_index: usize) -> usize;
-
-    /// Returns the index in the key view, given the index in the tree view.
-    ///
-    /// This is the inverse of [Self::tree_index].
-
-    fn key_index(tree_index: usize) -> usize;
+    /// The segmentation this ordering operates over.
+    type Segmentation: KeySegmentation<KEY_LEN>;
+    /// Order of segments from key layout to tree layout.
+    const SEGMENT_PERM: &'static [usize];
+    /// Maps each key index to its position in the tree view.
+    const KEY_TO_TREE: [usize; KEY_LEN];
+    /// Maps each tree index to its position in the key view.
+    const TREE_TO_KEY: [usize; KEY_LEN];
 
     /// Reorders the key from the shared key ordering to the tree ordering.
     fn tree_ordered(key: &[u8; KEY_LEN]) -> [u8; KEY_LEN] {
         let mut new_key = [0; KEY_LEN];
-        for i in 0..KEY_LEN {
-            new_key[Self::tree_index(i)] = key[i];
+        let mut i = 0;
+        while i < KEY_LEN {
+            new_key[Self::KEY_TO_TREE[i]] = key[i];
+            i += 1;
         }
         new_key
     }
@@ -77,8 +200,10 @@ pub trait KeyOrdering<const KEY_LEN: usize>: Copy + Clone + Debug {
     /// Reorders the key from the tree ordering to the shared key ordering.
     fn key_ordered(tree_key: &[u8; KEY_LEN]) -> [u8; KEY_LEN] {
         let mut new_key = [0; KEY_LEN];
-        for i in 0..KEY_LEN {
-            new_key[Self::key_index(i)] = tree_key[i];
+        let mut i = 0;
+        while i < KEY_LEN {
+            new_key[Self::TREE_TO_KEY[i]] = tree_key[i];
+            i += 1;
         }
         new_key
     }
@@ -95,8 +220,8 @@ pub trait KeyOrdering<const KEY_LEN: usize>: Copy + Clone + Debug {
 /// See [TribleSegmentation](crate::trible::TribleSegmentation) for an example that segments keys into entity,
 /// attribute, and value segments.
 pub trait KeySegmentation<const KEY_LEN: usize>: Copy + Clone + Debug {
-    /// Returns the segment index for the given key index.
-    fn segment(key_index: usize) -> usize;
+    /// Segment index for each position in the key.
+    const SEGMENTS: [usize; KEY_LEN];
 }
 
 /// A `KeyOrdering` that does not reorder the keys.
@@ -110,20 +235,15 @@ pub struct IdentityOrder {}
 /// This is the default segmentation.
 #[derive(Copy, Clone, Debug)]
 pub struct SingleSegmentation {}
-
 impl<const KEY_LEN: usize> KeyOrdering<KEY_LEN> for IdentityOrder {
-    fn key_index(tree_index: usize) -> usize {
-        tree_index
-    }
-    fn tree_index(key_index: usize) -> usize {
-        key_index
-    }
+    type Segmentation = SingleSegmentation;
+    const SEGMENT_PERM: &'static [usize] = &[0];
+    const KEY_TO_TREE: [usize; KEY_LEN] = identity_map::<KEY_LEN>();
+    const TREE_TO_KEY: [usize; KEY_LEN] = identity_map::<KEY_LEN>();
 }
 
 impl<const KEY_LEN: usize> KeySegmentation<KEY_LEN> for SingleSegmentation {
-    fn segment(_depth: usize) -> usize {
-        0
-    }
+    const SEGMENTS: [usize; KEY_LEN] = [0; KEY_LEN];
 }
 #[allow(dead_code)]
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -142,10 +262,9 @@ pub(crate) enum HeadTag {
     Leaf = 16,
 }
 
-pub(crate) enum BodyPtr<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
-{
+pub(crate) enum BodyPtr<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> {
     Leaf(NonNull<Leaf<KEY_LEN>>),
-    Branch(NonNull<Branch<KEY_LEN, O, S, [Option<Head<KEY_LEN, O, S>>]>>),
+    Branch(NonNull<Branch<KEY_LEN, O, [Option<Head<KEY_LEN, O>>]>>),
 }
 
 pub(crate) trait Body {
@@ -153,24 +272,16 @@ pub(crate) trait Body {
 }
 
 #[repr(C)]
-pub(crate) struct Head<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> {
+pub(crate) struct Head<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> {
     tptr: std::ptr::NonNull<u8>,
     key_ordering: PhantomData<O>,
-    key_segments: PhantomData<S>,
+    key_segments: PhantomData<O::Segmentation>,
 }
 
-unsafe impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> Send
-    for Head<KEY_LEN, O, S>
-{
-}
-unsafe impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> Sync
-    for Head<KEY_LEN, O, S>
-{
-}
+unsafe impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Send for Head<KEY_LEN, O> {}
+unsafe impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Sync for Head<KEY_LEN, O> {}
 
-impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
-    Head<KEY_LEN, O, S>
-{
+impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Head<KEY_LEN, O> {
     pub(crate) fn new<T: Body + ?Sized>(key: u8, body: NonNull<T>) -> Self {
         unsafe {
             let tptr =
@@ -217,14 +328,14 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
         }
     }
 
-    pub(crate) fn with_start(self, new_start_depth: usize) -> Head<KEY_LEN, O, S> {
+    pub(crate) fn with_start(self, new_start_depth: usize) -> Head<KEY_LEN, O> {
         let leaf_key = self.childleaf_key();
-        let i = O::key_index(new_start_depth);
+        let i = O::TREE_TO_KEY[new_start_depth];
         let key = leaf_key[i];
         self.with_key(key)
     }
 
-    pub(crate) fn body(&self) -> BodyPtr<KEY_LEN, O, S> {
+    pub(crate) fn body(&self) -> BodyPtr<KEY_LEN, O> {
         unsafe {
             let ptr = NonNull::new_unchecked(
                 self.tptr
@@ -239,13 +350,13 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
                         ptr.as_ptr(),
                         count,
                     )
-                        as *mut Branch<KEY_LEN, O, S, [Option<Head<KEY_LEN, O, S>>]>))
+                        as *mut Branch<KEY_LEN, O, [Option<Head<KEY_LEN, O>>]>))
                 }
             }
         }
     }
 
-    pub(crate) fn body_mut(&mut self) -> BodyPtr<KEY_LEN, O, S> {
+    pub(crate) fn body_mut(&mut self) -> BodyPtr<KEY_LEN, O> {
         unsafe {
             match self.body() {
                 BodyPtr::Leaf(leaf) => BodyPtr::Leaf(leaf),
@@ -310,7 +421,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
 
             let end_depth = std::cmp::min(this.end_depth(), KEY_LEN);
             for depth in start_depth..end_depth {
-                let i = O::key_index(depth);
+                let i = O::TREE_TO_KEY[depth];
                 if head_key[i] != leaf_key[i] {
                     return;
                 }
@@ -387,7 +498,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
 
         let end_depth = std::cmp::min(this.end_depth(), KEY_LEN);
         for depth in start_depth..end_depth {
-            let i = O::key_index(depth);
+            let i = O::TREE_TO_KEY[depth];
             let this_byte_key = this_key[i];
             let leaf_byte_key = leaf_key[i];
             if this_byte_key != leaf_byte_key {
@@ -427,7 +538,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
     {
         match self.body() {
             BodyPtr::Leaf(leaf) => {
-                Leaf::infixes::<PREFIX_LEN, INFIX_LEN, O, S, F>(leaf, prefix, at_depth, f)
+                Leaf::infixes::<PREFIX_LEN, INFIX_LEN, O, F>(leaf, prefix, at_depth, f)
             }
             BodyPtr::Branch(branch) => Branch::infixes(branch, prefix, at_depth, f),
         }
@@ -471,7 +582,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
         let this_key = this.childleaf_key();
         let other_key = other.childleaf_key();
         for depth in at_depth..std::cmp::min(this_depth, other_depth) {
-            let i = O::key_index(depth);
+            let i = O::TREE_TO_KEY[depth];
             let this_byte_key = this_key[i];
             let other_byte_key = other_key[i];
             if this_byte_key != other_byte_key {
@@ -559,7 +670,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
         let self_key = self.childleaf_key();
         let other_key = other.childleaf_key();
         for depth in at_depth..std::cmp::min(self_depth, other_depth) {
-            let i = O::key_index(depth);
+            let i = O::TREE_TO_KEY[depth];
             if self_key[i] != other_key[i] {
                 return None;
             }
@@ -575,7 +686,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
                 return branch
                     .as_ref()
                     .child_table
-                    .table_get(other.childleaf_key()[O::key_index(self_depth)])
+                    .table_get(other.childleaf_key()[O::TREE_TO_KEY[self_depth]])
                     .and_then(|self_child| other.intersect(self_child, self_depth));
             }
         }
@@ -591,7 +702,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
                 return other_branch
                     .as_ref()
                     .child_table
-                    .table_get(self.childleaf_key()[O::key_index(other_depth)])
+                    .table_get(self.childleaf_key()[O::TREE_TO_KEY[other_depth]])
                     .and_then(|other_child| self.intersect(other_child, other_depth));
             }
         }
@@ -655,7 +766,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
         let self_key = self.childleaf_key();
         let other_key = other.childleaf_key();
         for depth in at_depth..std::cmp::min(self_depth, other_depth) {
-            let i = O::key_index(depth);
+            let i = O::TREE_TO_KEY[depth];
             if self_key[i] != other_key[i] {
                 return Some(self.clone());
             }
@@ -672,7 +783,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
             let BodyPtr::Branch(branch) = new_branch.body_mut() else {
                 unreachable!();
             };
-            let other_byte_key = other.childleaf_key()[O::key_index(self_depth)];
+            let other_byte_key = other.childleaf_key()[O::TREE_TO_KEY[self_depth]];
             Branch::update_child(branch, other_byte_key, |child| {
                 child.difference(other, self_depth)
             });
@@ -689,7 +800,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
             let BodyPtr::Branch(other_branch) = other.body() else {
                 unreachable!();
             };
-            let self_byte_key = self.childleaf_key()[O::key_index(other_depth)];
+            let self_byte_key = self.childleaf_key()[O::TREE_TO_KEY[other_depth]];
 
             if let Some(other_child) =
                 unsafe { other_branch.as_ref().child_table.table_get(self_byte_key) }
@@ -749,25 +860,19 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
     }
 }
 
-unsafe impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> ByteEntry
-    for Head<KEY_LEN, O, S>
-{
+unsafe impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> ByteEntry for Head<KEY_LEN, O> {
     fn key(&self) -> u8 {
         self.key()
     }
 }
 
-impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> fmt::Debug
-    for Head<KEY_LEN, O, S>
-{
+impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> fmt::Debug for Head<KEY_LEN, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.tag().fmt(f)
     }
 }
 
-impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> Clone
-    for Head<KEY_LEN, O, S>
-{
+impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Clone for Head<KEY_LEN, O> {
     fn clone(&self) -> Self {
         unsafe {
             match self.body() {
@@ -778,9 +883,7 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
     }
 }
 
-impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> Drop
-    for Head<KEY_LEN, O, S>
-{
+impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Drop for Head<KEY_LEN, O> {
     fn drop(&mut self) {
         unsafe {
             match self.body() {
@@ -807,18 +910,16 @@ impl<const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
 ///
 /// The PATCH allows for cheap copy-on-write operations, with `clone` being O(1).
 #[derive(Debug, Clone)]
-pub struct PATCH<
-    const KEY_LEN: usize,
-    O: KeyOrdering<KEY_LEN> = IdentityOrder,
-    S: KeySegmentation<KEY_LEN> = SingleSegmentation,
-> {
-    root: Option<Head<KEY_LEN, O, S>>,
-}
-
-impl<const KEY_LEN: usize, O, S> PATCH<KEY_LEN, O, S>
+pub struct PATCH<const KEY_LEN: usize, O = IdentityOrder>
 where
     O: KeyOrdering<KEY_LEN>,
-    S: KeySegmentation<KEY_LEN>,
+{
+    root: Option<Head<KEY_LEN, O>>,
+}
+
+impl<const KEY_LEN: usize, O> PATCH<KEY_LEN, O>
+where
+    O: KeyOrdering<KEY_LEN>,
 {
     /// Creates a new empty PATCH.
     pub fn new() -> Self {
@@ -880,13 +981,15 @@ where
             assert!(PREFIX_LEN + INFIX_LEN <= KEY_LEN);
         }
         assert!(
-            S::segment(O::key_index(PREFIX_LEN))
-                == S::segment(O::key_index(PREFIX_LEN + INFIX_LEN - 1)),
+            <O as KeyOrdering<KEY_LEN>>::Segmentation::SEGMENTS[O::TREE_TO_KEY[PREFIX_LEN]]
+                == <O as KeyOrdering<KEY_LEN>>::Segmentation::SEGMENTS
+                    [O::TREE_TO_KEY[PREFIX_LEN + INFIX_LEN - 1]],
             "PREFIX_LEN = {}, INFIX_LEN = {}, {} != {}",
             PREFIX_LEN,
             INFIX_LEN,
-            S::segment(O::key_index(PREFIX_LEN)),
-            S::segment(O::key_index(PREFIX_LEN + INFIX_LEN - 1))
+            <O as KeyOrdering<KEY_LEN>>::Segmentation::SEGMENTS[O::TREE_TO_KEY[PREFIX_LEN]],
+            <O as KeyOrdering<KEY_LEN>>::Segmentation::SEGMENTS
+                [O::TREE_TO_KEY[PREFIX_LEN + INFIX_LEN - 1]]
         );
         if let Some(root) = &self.root {
             root.infixes(prefix, 0, &mut for_each);
@@ -919,13 +1022,13 @@ where
 
     /// Iterates over all keys in the PATCH.
     /// The keys are returned in key ordering but random order.
-    pub fn iter<'a>(&'a self) -> PATCHIterator<'a, KEY_LEN, O, S> {
+    pub fn iter<'a>(&'a self) -> PATCHIterator<'a, KEY_LEN, O> {
         PATCHIterator::new(self)
     }
 
     /// Iterates over all keys in the PATCH.
     /// The keys are returned in key ordering and tree order.
-    pub fn iter_ordered<'a>(&'a self) -> PATCHOrderedIterator<'a, KEY_LEN, O, S> {
+    pub fn iter_ordered<'a>(&'a self) -> PATCHOrderedIterator<'a, KEY_LEN, O> {
         PATCHOrderedIterator::new(self)
     }
 
@@ -934,7 +1037,7 @@ where
     /// A count of the number of elements for the given prefix is also returned.
     pub fn iter_prefix_count<'a, const PREFIX_LEN: usize>(
         &'a self,
-    ) -> PATCHPrefixIterator<'a, KEY_LEN, PREFIX_LEN, O, S> {
+    ) -> PATCHPrefixIterator<'a, KEY_LEN, PREFIX_LEN, O> {
         PATCHPrefixIterator::new(self)
     }
 
@@ -1023,30 +1126,23 @@ where
     }
 }
 
-impl<const KEY_LEN: usize, O, S> PartialEq for PATCH<KEY_LEN, O, S>
+impl<const KEY_LEN: usize, O> PartialEq for PATCH<KEY_LEN, O>
 where
     O: KeyOrdering<KEY_LEN>,
-    S: KeySegmentation<KEY_LEN>,
 {
     fn eq(&self, other: &Self) -> bool {
         self.root.as_ref().map(|root| root.hash()) == other.root.as_ref().map(|root| root.hash())
     }
 }
 
-impl<const KEY_LEN: usize, O, S> Eq for PATCH<KEY_LEN, O, S>
-where
-    O: KeyOrdering<KEY_LEN>,
-    S: KeySegmentation<KEY_LEN>,
-{
-}
+impl<const KEY_LEN: usize, O> Eq for PATCH<KEY_LEN, O> where O: KeyOrdering<KEY_LEN> {}
 
-impl<'a, const KEY_LEN: usize, O, S> IntoIterator for &'a PATCH<KEY_LEN, O, S>
+impl<'a, const KEY_LEN: usize, O> IntoIterator for &'a PATCH<KEY_LEN, O>
 where
     O: KeyOrdering<KEY_LEN>,
-    S: KeySegmentation<KEY_LEN>,
 {
     type Item = &'a [u8; KEY_LEN];
-    type IntoIter = PATCHIterator<'a, KEY_LEN, O, S>;
+    type IntoIter = PATCHIterator<'a, KEY_LEN, O>;
 
     fn into_iter(self) -> Self::IntoIter {
         PATCHIterator::new(self)
@@ -1055,19 +1151,12 @@ where
 
 /// An iterator over all keys in a PATCH.
 /// The keys are returned in key ordering but in random order.
-pub struct PATCHIterator<
-    'a,
-    const KEY_LEN: usize,
-    O: KeyOrdering<KEY_LEN>,
-    S: KeySegmentation<KEY_LEN>,
-> {
-    stack: ArrayVec<std::slice::Iter<'a, Option<Head<KEY_LEN, O, S>>>, KEY_LEN>,
+pub struct PATCHIterator<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> {
+    stack: ArrayVec<std::slice::Iter<'a, Option<Head<KEY_LEN, O>>>, KEY_LEN>,
 }
 
-impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
-    PATCHIterator<'a, KEY_LEN, O, S>
-{
-    fn new(patch: &'a PATCH<KEY_LEN, O, S>) -> Self {
+impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> PATCHIterator<'a, KEY_LEN, O> {
+    fn new(patch: &'a PATCH<KEY_LEN, O>) -> Self {
         let mut r = PATCHIterator {
             stack: ArrayVec::new(),
         };
@@ -1076,9 +1165,7 @@ impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_L
     }
 }
 
-impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> Iterator
-    for PATCHIterator<'a, KEY_LEN, O, S>
-{
+impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Iterator for PATCHIterator<'a, KEY_LEN, O> {
     type Item = &'a [u8; KEY_LEN];
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1106,19 +1193,12 @@ impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_L
 
 /// An iterator over all keys in a PATCH that have a given prefix.
 /// The keys are returned in tree ordering and in tree order.
-pub struct PATCHOrderedIterator<
-    'a,
-    const KEY_LEN: usize,
-    O: KeyOrdering<KEY_LEN>,
-    S: KeySegmentation<KEY_LEN>,
-> {
-    stack: Vec<ArrayVec<&'a Head<KEY_LEN, O, S>, 256>>,
+pub struct PATCHOrderedIterator<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> {
+    stack: Vec<ArrayVec<&'a Head<KEY_LEN, O>, 256>>,
 }
 
-impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
-    PATCHOrderedIterator<'a, KEY_LEN, O, S>
-{
-    fn new(patch: &'a PATCH<KEY_LEN, O, S>) -> Self {
+impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> PATCHOrderedIterator<'a, KEY_LEN, O> {
+    fn new(patch: &'a PATCH<KEY_LEN, O>) -> Self {
         let mut r = PATCHOrderedIterator {
             stack: Vec::with_capacity(KEY_LEN),
         };
@@ -1145,8 +1225,8 @@ impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_L
     }
 }
 
-impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>> Iterator
-    for PATCHOrderedIterator<'a, KEY_LEN, O, S>
+impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Iterator
+    for PATCHOrderedIterator<'a, KEY_LEN, O>
 {
     type Item = &'a [u8; KEY_LEN];
 
@@ -1186,20 +1266,14 @@ pub struct PATCHPrefixIterator<
     const KEY_LEN: usize,
     const PREFIX_LEN: usize,
     O: KeyOrdering<KEY_LEN>,
-    S: KeySegmentation<KEY_LEN>,
 > {
-    stack: Vec<ArrayVec<&'a Head<KEY_LEN, O, S>, 256>>,
+    stack: Vec<ArrayVec<&'a Head<KEY_LEN, O>, 256>>,
 }
 
-impl<
-        'a,
-        const KEY_LEN: usize,
-        const PREFIX_LEN: usize,
-        O: KeyOrdering<KEY_LEN>,
-        S: KeySegmentation<KEY_LEN>,
-    > PATCHPrefixIterator<'a, KEY_LEN, PREFIX_LEN, O, S>
+impl<'a, const KEY_LEN: usize, const PREFIX_LEN: usize, O: KeyOrdering<KEY_LEN>>
+    PATCHPrefixIterator<'a, KEY_LEN, PREFIX_LEN, O>
 {
-    fn new(patch: &'a PATCH<KEY_LEN, O, S>) -> Self {
+    fn new(patch: &'a PATCH<KEY_LEN, O>) -> Self {
         const {
             assert!(PREFIX_LEN <= KEY_LEN);
         }
@@ -1231,13 +1305,8 @@ impl<
     }
 }
 
-impl<
-        'a,
-        const KEY_LEN: usize,
-        const PREFIX_LEN: usize,
-        O: KeyOrdering<KEY_LEN>,
-        S: KeySegmentation<KEY_LEN>,
-    > Iterator for PATCHPrefixIterator<'a, KEY_LEN, PREFIX_LEN, O, S>
+impl<'a, const KEY_LEN: usize, const PREFIX_LEN: usize, O: KeyOrdering<KEY_LEN>> Iterator
+    for PATCHPrefixIterator<'a, KEY_LEN, PREFIX_LEN, O>
 {
     type Item = ([u8; PREFIX_LEN], u64);
 
@@ -1286,8 +1355,7 @@ mod tests {
 
     #[test]
     fn head_tag() {
-        let head =
-            Head::<64, IdentityOrder, SingleSegmentation>::new::<Leaf<64>>(0, NonNull::dangling());
+        let head = Head::<64, IdentityOrder>::new::<Leaf<64>>(0, NonNull::dangling());
         assert_eq!(head.tag(), HeadTag::Leaf);
         mem::forget(head);
     }
@@ -1295,10 +1363,7 @@ mod tests {
     #[test]
     fn head_key() {
         for k in 0..=255 {
-            let head = Head::<64, IdentityOrder, SingleSegmentation>::new::<Leaf<64>>(
-                k,
-                NonNull::dangling(),
-            );
+            let head = Head::<64, IdentityOrder>::new::<Leaf<64>>(k, NonNull::dangling());
             assert_eq!(head.key(), k);
             mem::forget(head);
         }
@@ -1306,21 +1371,18 @@ mod tests {
 
     #[test]
     fn head_size() {
-        assert_eq!(
-            mem::size_of::<Head<64, IdentityOrder, SingleSegmentation>>(),
-            8
-        );
+        assert_eq!(mem::size_of::<Head<64, IdentityOrder>>(), 8);
     }
 
     #[test]
     fn empty_tree() {
-        let _tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+        let _tree = PATCH::<64, IdentityOrder>::new();
     }
 
     #[test]
     fn tree_put_one() {
         const KEY_SIZE: usize = 64;
-        let mut tree = PATCH::<KEY_SIZE, IdentityOrder, SingleSegmentation>::new();
+        let mut tree = PATCH::<KEY_SIZE, IdentityOrder>::new();
         let entry = Entry::new(&[0; KEY_SIZE]);
         tree.insert(&entry);
     }
@@ -1328,7 +1390,7 @@ mod tests {
     #[test]
     fn tree_put_same() {
         const KEY_SIZE: usize = 64;
-        let mut tree = PATCH::<KEY_SIZE, IdentityOrder, SingleSegmentation>::new();
+        let mut tree = PATCH::<KEY_SIZE, IdentityOrder>::new();
         let entry = Entry::new(&[0; KEY_SIZE]);
         tree.insert(&entry);
         tree.insert(&entry);
@@ -1337,91 +1399,35 @@ mod tests {
     #[test]
     fn branch_size() {
         assert_eq!(
-            mem::size_of::<
-                Branch<
-                    64,
-                    IdentityOrder,
-                    SingleSegmentation,
-                    [Option<Head<64, IdentityOrder, SingleSegmentation>>; 2],
-                >,
-            >(),
+            mem::size_of::<Branch<64, IdentityOrder, [Option<Head<64, IdentityOrder>>; 2]>>(),
             64
         );
         assert_eq!(
-            mem::size_of::<
-                Branch<
-                    64,
-                    IdentityOrder,
-                    SingleSegmentation,
-                    [Option<Head<64, IdentityOrder, SingleSegmentation>>; 4],
-                >,
-            >(),
+            mem::size_of::<Branch<64, IdentityOrder, [Option<Head<64, IdentityOrder>>; 4]>>(),
             48 + 16 * 2
         );
         assert_eq!(
-            mem::size_of::<
-                Branch<
-                    64,
-                    IdentityOrder,
-                    SingleSegmentation,
-                    [Option<Head<64, IdentityOrder, SingleSegmentation>>; 8],
-                >,
-            >(),
+            mem::size_of::<Branch<64, IdentityOrder, [Option<Head<64, IdentityOrder>>; 8]>>(),
             48 + 16 * 4
         );
         assert_eq!(
-            mem::size_of::<
-                Branch<
-                    64,
-                    IdentityOrder,
-                    SingleSegmentation,
-                    [Option<Head<64, IdentityOrder, SingleSegmentation>>; 16],
-                >,
-            >(),
+            mem::size_of::<Branch<64, IdentityOrder, [Option<Head<64, IdentityOrder>>; 16]>>(),
             48 + 16 * 8
         );
         assert_eq!(
-            mem::size_of::<
-                Branch<
-                    64,
-                    IdentityOrder,
-                    SingleSegmentation,
-                    [Option<Head<32, IdentityOrder, SingleSegmentation>>; 32],
-                >,
-            >(),
+            mem::size_of::<Branch<64, IdentityOrder, [Option<Head<32, IdentityOrder>>; 32]>>(),
             48 + 16 * 16
         );
         assert_eq!(
-            mem::size_of::<
-                Branch<
-                    64,
-                    IdentityOrder,
-                    SingleSegmentation,
-                    [Option<Head<64, IdentityOrder, SingleSegmentation>>; 64],
-                >,
-            >(),
+            mem::size_of::<Branch<64, IdentityOrder, [Option<Head<64, IdentityOrder>>; 64]>>(),
             48 + 16 * 32
         );
         assert_eq!(
-            mem::size_of::<
-                Branch<
-                    64,
-                    IdentityOrder,
-                    SingleSegmentation,
-                    [Option<Head<64, IdentityOrder, SingleSegmentation>>; 128],
-                >,
-            >(),
+            mem::size_of::<Branch<64, IdentityOrder, [Option<Head<64, IdentityOrder>>; 128]>>(),
             48 + 16 * 64
         );
         assert_eq!(
-            mem::size_of::<
-                Branch<
-                    64,
-                    IdentityOrder,
-                    SingleSegmentation,
-                    [Option<Head<64, IdentityOrder, SingleSegmentation>>; 256],
-                >,
-            >(),
+            mem::size_of::<Branch<64, IdentityOrder, [Option<Head<64, IdentityOrder>>; 256]>>(),
             48 + 16 * 128
         );
     }
@@ -1431,8 +1437,8 @@ mod tests {
     #[test]
     fn tree_union_single() {
         const KEY_SIZE: usize = 8;
-        let mut left = PATCH::<KEY_SIZE, IdentityOrder, SingleSegmentation>::new();
-        let mut right = PATCH::<KEY_SIZE, IdentityOrder, SingleSegmentation>::new();
+        let mut left = PATCH::<KEY_SIZE, IdentityOrder>::new();
+        let mut right = PATCH::<KEY_SIZE, IdentityOrder>::new();
         let left_entry = Entry::new(&[0, 0, 0, 0, 0, 0, 0, 0]);
         let right_entry = Entry::new(&[0, 0, 0, 0, 0, 0, 0, 1]);
         left.insert(&left_entry);
@@ -1444,7 +1450,7 @@ mod tests {
     proptest! {
         #[test]
         fn tree_insert(keys in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 1..1024)) {
-            let mut tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut tree = PATCH::<64, IdentityOrder>::new();
             for key in keys {
                 let key: [u8; 64] = key.try_into().unwrap();
                 let entry = Entry::new(&key);
@@ -1454,7 +1460,7 @@ mod tests {
 
         #[test]
         fn tree_len(keys in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 1..1024)) {
-            let mut tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut tree = PATCH::<64, IdentityOrder>::new();
             let mut set = HashSet::new();
             for key in keys {
                 let key: [u8; 64] = key.try_into().unwrap();
@@ -1468,7 +1474,7 @@ mod tests {
 
         #[test]
         fn tree_infixes(keys in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 1..1024)) {
-            let mut tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut tree = PATCH::<64, IdentityOrder>::new();
             let mut set = HashSet::new();
             for key in keys {
                 let key: [u8; 64] = key.try_into().unwrap();
@@ -1488,7 +1494,7 @@ mod tests {
 
         #[test]
         fn tree_iter(keys in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 1..1024)) {
-            let mut tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut tree = PATCH::<64, IdentityOrder>::new();
             let mut set = HashSet::new();
             for key in keys {
                 let key: [u8; 64] = key.try_into().unwrap();
@@ -1513,7 +1519,7 @@ mod tests {
                         right in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 200)) {
             let mut set = HashSet::new();
 
-            let mut left_tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut left_tree = PATCH::<64, IdentityOrder>::new();
             for entry in left {
                 let mut key = [0; 64];
                 key.iter_mut().set_from(entry.iter().cloned());
@@ -1522,7 +1528,7 @@ mod tests {
                 set.insert(key);
             }
 
-            let mut right_tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut right_tree = PATCH::<64, IdentityOrder>::new();
             for entry in right {
                 let mut key = [0; 64];
                 key.iter_mut().set_from(entry.iter().cloned());
@@ -1547,7 +1553,7 @@ mod tests {
         fn tree_union_empty(left in prop::collection::vec(prop::collection::vec(0u8..=255, 64), 2)) {
             let mut set = HashSet::new();
 
-            let mut left_tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let mut left_tree = PATCH::<64, IdentityOrder>::new();
             for entry in left {
                 let mut key = [0; 64];
                 key.iter_mut().set_from(entry.iter().cloned());
@@ -1556,7 +1562,7 @@ mod tests {
                 set.insert(key);
             }
 
-            let right_tree = PATCH::<64, IdentityOrder, SingleSegmentation>::new();
+            let right_tree = PATCH::<64, IdentityOrder>::new();
 
             left_tree.union(right_tree);
 
@@ -1581,7 +1587,7 @@ mod tests {
             // which might not be affected by nodes in lower levels being changed accidentally.
             // Instead we need to iterate over the keys and check if they are the same.
 
-            let mut tree = PATCH::<8, IdentityOrder, SingleSegmentation>::new();
+            let mut tree = PATCH::<8, IdentityOrder>::new();
             for key in base_keys {
                 let key: [u8; 8] = key[..].try_into().unwrap();
                 let entry = Entry::new(&key);
@@ -1607,7 +1613,7 @@ mod tests {
             // which might not be affected by nodes in lower levels being changed accidentally.
             // Instead we need to iterate over the keys and check if they are the same.
 
-            let mut tree = PATCH::<8, IdentityOrder, SingleSegmentation>::new();
+            let mut tree = PATCH::<8, IdentityOrder>::new();
             for key in base_keys {
                 let key: [u8; 8] = key[..].try_into().unwrap();
                 let entry = Entry::new(&key);
@@ -1616,7 +1622,7 @@ mod tests {
             let base_tree_content: Vec<[u8; 8]> = tree.iter().copied().collect();
 
             let mut tree_clone = tree.clone();
-            let mut new_tree = PATCH::<8, IdentityOrder, SingleSegmentation>::new();
+            let mut new_tree = PATCH::<8, IdentityOrder>::new();
             for key in new_keys {
                 let key: [u8; 8] = key[..].try_into().unwrap();
                 let entry = Entry::new(&key);

--- a/src/patch/entry.rs
+++ b/src/patch/entry.rs
@@ -14,9 +14,7 @@ impl<const KEY_LEN: usize> Entry<KEY_LEN> {
         }
     }
 
-    pub(super) fn leaf<O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>(
-        &self,
-    ) -> Head<KEY_LEN, O, S> {
+    pub(super) fn leaf<O: KeyOrdering<KEY_LEN>>(&self) -> Head<KEY_LEN, O> {
         unsafe { Head::new(0, Leaf::rc_inc(self.ptr)) }
     }
 }

--- a/src/patch/leaf.rs
+++ b/src/patch/leaf.rs
@@ -81,7 +81,6 @@ impl<const KEY_LEN: usize> Leaf<KEY_LEN> {
         const PREFIX_LEN: usize,
         const INFIX_LEN: usize,
         O: KeyOrdering<KEY_LEN>,
-        S: KeySegmentation<KEY_LEN>,
         F,
     >(
         leaf: NonNull<Self>,
@@ -94,13 +93,13 @@ impl<const KEY_LEN: usize> Leaf<KEY_LEN> {
         let leaf = unsafe { leaf.as_ref() };
         let leaf_key = (*leaf).key;
         for depth in at_depth..PREFIX_LEN {
-            if leaf_key[O::key_index(depth)] != prefix[depth] {
+            if leaf_key[O::TREE_TO_KEY[depth]] != prefix[depth] {
                 return;
             }
         }
 
         let infix: [u8; INFIX_LEN] =
-            core::array::from_fn(|i| (*leaf).key[O::key_index(PREFIX_LEN + i)]);
+            core::array::from_fn(|i| (*leaf).key[O::TREE_TO_KEY[PREFIX_LEN + i]]);
         f(&infix);
     }
 
@@ -114,7 +113,7 @@ impl<const KEY_LEN: usize> Leaf<KEY_LEN> {
         }
         let leaf_key: &[u8; KEY_LEN] = unsafe { &(*leaf.as_ptr()).key };
         for depth in at_depth..PREFIX_LEN {
-            if leaf_key[O::key_index(depth)] != prefix[depth] {
+            if leaf_key[O::TREE_TO_KEY[depth]] != prefix[depth] {
                 return false;
             }
         }
@@ -128,7 +127,7 @@ impl<const KEY_LEN: usize> Leaf<KEY_LEN> {
     ) -> u64 {
         let leaf_key: &[u8; KEY_LEN] = unsafe { &(*leaf.as_ptr()).key };
         for depth in at_depth..PREFIX_LEN {
-            let key_depth = O::key_index(depth);
+            let key_depth = O::TREE_TO_KEY[depth];
             if leaf_key[key_depth] != prefix[depth] {
                 return 0;
             }

--- a/src/query/patchconstraint.rs
+++ b/src/query/patchconstraint.rs
@@ -1,6 +1,6 @@
 use crate::{
     id::{id_from_value, id_into_value, ID_LEN},
-    patch::{IdentityOrder, SingleSegmentation, PATCH},
+    patch::{IdentityOrder, PATCH},
     value::{RawValue, ValueSchema, VALUE_LEN},
 };
 
@@ -8,14 +8,11 @@ use super::{Binding, Constraint, ContainsConstraint, Variable, VariableId, Varia
 
 pub struct PatchValueConstraint<'a, T: ValueSchema> {
     variable: Variable<T>,
-    patch: &'a PATCH<VALUE_LEN, IdentityOrder, SingleSegmentation>,
+    patch: &'a PATCH<VALUE_LEN, IdentityOrder>,
 }
 
 impl<'a, T: ValueSchema> PatchValueConstraint<'a, T> {
-    pub fn new(
-        variable: Variable<T>,
-        patch: &'a PATCH<VALUE_LEN, IdentityOrder, SingleSegmentation>,
-    ) -> Self {
+    pub fn new(variable: Variable<T>, patch: &'a PATCH<VALUE_LEN, IdentityOrder>) -> Self {
         PatchValueConstraint { variable, patch }
     }
 }
@@ -47,9 +44,7 @@ impl<'a, S: ValueSchema> Constraint<'a> for PatchValueConstraint<'a, S> {
     }
 }
 
-impl<'a, S: ValueSchema> ContainsConstraint<'a, S>
-    for &'a PATCH<VALUE_LEN, IdentityOrder, SingleSegmentation>
-{
+impl<'a, S: ValueSchema> ContainsConstraint<'a, S> for &'a PATCH<VALUE_LEN, IdentityOrder> {
     type Constraint = PatchValueConstraint<'a, S>;
 
     fn has(self, v: Variable<S>) -> Self::Constraint {
@@ -62,17 +57,14 @@ where
     S: ValueSchema,
 {
     variable: Variable<S>,
-    patch: PATCH<ID_LEN, IdentityOrder, SingleSegmentation>,
+    patch: PATCH<ID_LEN, IdentityOrder>,
 }
 
 impl<'a, S> PatchIdConstraint<S>
 where
     S: ValueSchema,
 {
-    pub fn new(
-        variable: Variable<S>,
-        patch: PATCH<ID_LEN, IdentityOrder, SingleSegmentation>,
-    ) -> Self {
+    pub fn new(variable: Variable<S>, patch: PATCH<ID_LEN, IdentityOrder>) -> Self {
         PatchIdConstraint { variable, patch }
     }
 }
@@ -112,9 +104,7 @@ where
     }
 }
 
-impl<'a, S: ValueSchema> ContainsConstraint<'a, S>
-    for PATCH<ID_LEN, IdentityOrder, SingleSegmentation>
-{
+impl<'a, S: ValueSchema> ContainsConstraint<'a, S> for PATCH<ID_LEN, IdentityOrder> {
     type Constraint = PatchIdConstraint<S>;
 
     fn has(self, v: Variable<S>) -> Self::Constraint {

--- a/src/query/regularpathconstraint.rs
+++ b/src/query/regularpathconstraint.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::id::{id_from_value, id_into_value, RawId, ID_LEN};
-use crate::patch::{Entry, IdentityOrder, SingleSegmentation, PATCH};
+use crate::patch::{Entry, IdentityOrder, PATCH};
 use crate::query::{Binding, Constraint, Variable, VariableId, VariableSet};
 use crate::trible::TribleSet;
 use crate::trible::{A_END, A_START, E_END, E_START, V_START};
@@ -27,7 +27,7 @@ const NIL_ID: RawId = [0; ID_LEN];
 
 #[derive(Clone)]
 struct Automaton {
-    transitions: PATCH<EDGE_KEY_LEN, IdentityOrder, SingleSegmentation>,
+    transitions: PATCH<EDGE_KEY_LEN, IdentityOrder>,
     start: u64,
     accept: u64,
 }
@@ -50,7 +50,7 @@ impl Automaton {
         }
 
         fn insert_edge(
-            patch: &mut PATCH<EDGE_KEY_LEN, IdentityOrder, SingleSegmentation>,
+            patch: &mut PATCH<EDGE_KEY_LEN, IdentityOrder>,
             from: &u64,
             label: &RawId,
             to: &u64,
@@ -62,7 +62,7 @@ impl Automaton {
             patch.insert(&Entry::new(&key));
         }
 
-        let mut trans = PATCH::<EDGE_KEY_LEN, IdentityOrder, SingleSegmentation>::new();
+        let mut trans = PATCH::<EDGE_KEY_LEN, IdentityOrder>::new();
         let mut counter: u64 = 0;
         let mut stack: Vec<Frag> = Vec::new();
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -125,7 +125,7 @@ use crate::{
     find,
     id::Id,
     metadata::metadata,
-    patch::{Entry, IdentityOrder, SingleSegmentation, PATCH},
+    patch::{Entry, IdentityOrder, PATCH},
     trible::TribleSet,
     value::VALUE_LEN,
     value::{
@@ -804,7 +804,7 @@ where
 }
 
 type CommitHandle = Value<Handle<Blake3, SimpleArchive>>;
-type CommitSet = PATCH<VALUE_LEN, IdentityOrder, SingleSegmentation>;
+type CommitSet = PATCH<VALUE_LEN, IdentityOrder>;
 type BranchMetaHandle = Value<Handle<Blake3, SimpleArchive>>;
 
 /// The Workspace represents the mutable working area or "staging" state.

--- a/src/trible/tribleset.rs
+++ b/src/trible/tribleset.rs
@@ -7,8 +7,7 @@ use crate::query::TriblePattern;
 use crate::patch::{Entry, PATCH};
 use crate::query::Variable;
 use crate::trible::{
-    AEVOrder, AVEOrder, EAVOrder, EVAOrder, Trible, TribleSegmentation, VAEOrder, VEAOrder,
-    TRIBLE_LEN,
+    AEVOrder, AVEOrder, EAVOrder, EVAOrder, Trible, VAEOrder, VEAOrder, TRIBLE_LEN,
 };
 use crate::value::{schemas::genid::GenId, ValueSchema};
 
@@ -31,19 +30,16 @@ use std::ops::{Add, AddAssign};
 /// and not to remove elements from the set. A subtle but important distinction.
 #[derive(Debug, Clone)]
 pub struct TribleSet {
-    pub eav: PATCH<TRIBLE_LEN, EAVOrder, TribleSegmentation>,
-    pub vea: PATCH<TRIBLE_LEN, VEAOrder, TribleSegmentation>,
-    pub ave: PATCH<TRIBLE_LEN, AVEOrder, TribleSegmentation>,
-    pub vae: PATCH<TRIBLE_LEN, VAEOrder, TribleSegmentation>,
-    pub eva: PATCH<TRIBLE_LEN, EVAOrder, TribleSegmentation>,
-    pub aev: PATCH<TRIBLE_LEN, AEVOrder, TribleSegmentation>,
+    pub eav: PATCH<TRIBLE_LEN, EAVOrder>,
+    pub vea: PATCH<TRIBLE_LEN, VEAOrder>,
+    pub ave: PATCH<TRIBLE_LEN, AVEOrder>,
+    pub vae: PATCH<TRIBLE_LEN, VAEOrder>,
+    pub eva: PATCH<TRIBLE_LEN, EVAOrder>,
+    pub aev: PATCH<TRIBLE_LEN, AEVOrder>,
 }
 
 pub struct TribleSetIterator<'a> {
-    inner: Map<
-        crate::patch::PATCHIterator<'a, 64, EAVOrder, TribleSegmentation>,
-        fn(&[u8; 64]) -> &Trible,
-    >,
+    inner: Map<crate::patch::PATCHIterator<'a, 64, EAVOrder>, fn(&[u8; 64]) -> &Trible>,
 }
 
 impl TribleSet {


### PR DESCRIPTION
## Summary
- remove index helper methods and operate directly on const translation tables
- tie KeyOrdering to KeySegmentation and record segment permutations
- note follow-up for segment iterators in the inventory
- make KeyOrdering specify its segmentation via an associated type instead of a generic parameter
- introduce macros `key_segmentation!` and `key_ordering!` that build `KeySegmentation` and `KeyOrdering` implementations from declarative descriptions

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688f7260a5848322ab8c84001aa5ef28