### PR TITLE
Move verbose module docs to book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the reified `ByteBucket` abstraction and indexed buckets directly in the byte table.
 - `ByteSet` now stores raw `[u128; 2]` bitsets instead of relying on `VariableSet`.
 - Detailed query engine documentation moved from the `query` module to the book, leaving a concise overview in code.
+- Moved verbose inline documentation for Pile, Trible, Blob and PATCH modules
+  into the book.
+- Expanded Trible Structure deep-dive with design rationale and advantages
+  previously kept inline.
+- Added remaining rationale from the blob, patch, pile and schema docs to the
+  corresponding book chapters so code comments stay concise without losing
+  detail.
 ### Fixed
 - ByteTable resize benchmark now reports load factor for fully populated 256-slot tables.
 - `PatchIdConstraint` incorrectly used 32-byte values when confirming IDs, causing

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Philosophy](deep-dive/philosophy.md)
   - [Identifiers](deep-dive/identifiers.md)
   - [Trible Structure](deep-dive/trible-structure.md)
+  - [Blobs](deep-dive/blobs.md)
   - [PATCH](deep-dive/patch.md)
   - [Pile Format](pile-format.md)
   - [Pile Blob Metadata](pile-metadata-proposal.md)

--- a/book/src/deep-dive/blobs.md
+++ b/book/src/deep-dive/blobs.md
@@ -1,0 +1,64 @@
+# Blobs
+
+Blobs are immutable sequences of bytes used to represent data that does not fit into the fixed 256‑bit value slot of a trible. Each blob is typed by a `BlobSchema` similar to how values use `ValueSchema`. This allows structured data to be serialized into a blob while still tracking its schema.
+
+Values and tribles capture small facts in a fixed width, whereas blobs are used "in the large" for documents, media and other sizable payloads. A blob can therefore represent anything from a single file to a complete archive of tribles.
+
+Converting Rust types to blobs is infallible in practice, so only the `ToBlob` and `TryFromBlob` traits are widely used. The `TryToBlob` and `FromBlob` variants have been dropped to keep the API surface small.
+
+The following example demonstrates creating blobs, archiving a `TribleSet` and signing its contents:
+
+```rust
+use tribles::prelude::*;
+use tribles::examples::literature;
+use tribles::repo::repo;
+use valueschemas::{Handle, Blake3};
+use blobschemas::{SimpleArchive, LongString};
+use rand::rngs::OsRng;
+use ed25519_dalek::{Signature, Signer, SigningKey};
+
+// Build a BlobStore and fill it with some data.
+let mut memory_store: MemoryBlobStore<Blake3> = MemoryBlobStore::new();
+
+let book_author_id = fucid();
+let quote_a: Value<Handle<Blake3, LongString>> = memory_store
+    .put("Deep in the human unconscious is a pervasive need for a logical universe that makes sense. But the real universe is always one step beyond logic.")
+    .unwrap();
+let quote_b = memory_store
+    .put("I must not fear. Fear is the mind-killer. Fear is the little-death that brings total obliteration. I will face my fear. I will permit it to pass over me and through me. And when it has gone past I will turn the inner eye to see its path. Where the fear has gone there will be nothing. Only I will remain.")
+    .unwrap();
+
+let set = literature::entity!({
+   title: "Dune",
+   author: &book_author_id,
+   quote: quote_a,
+   quote: quote_b
+});
+
+// Serialize the TribleSet and store it as another blob.
+let archived_set_handle: Value<Handle<Blake3, SimpleArchive>> = memory_store.put(&set).unwrap();
+
+let mut csprng = OsRng;
+let commit_author_key: SigningKey = SigningKey::generate(&mut csprng);
+let signature: Signature = commit_author_key.sign(
+    &memory_store
+        .reader()
+        .get::<Blob<SimpleArchive>, SimpleArchive>(archived_set_handle)
+        .unwrap()
+        .bytes,
+);
+
+// Store the handle in another TribleSet.
+let _meta_set = repo::entity!({
+   content: archived_set_handle,
+   short_message: "Initial commit",
+   signed_by: commit_author_key.verifying_key(),
+   signature_r: signature,
+   signature_s: signature,
+});
+```
+
+Blobs complement tribles and values by handling large payloads while keeping the
+core data structures compact. A blob's hash, computed via a chosen
+`HashProtocol`, acts as a stable handle that can be embedded into tribles or
+other blobs, enabling content‑addressed references without copying the payload.

--- a/book/src/deep-dive/patch.md
+++ b/book/src/deep-dive/patch.md
@@ -54,6 +54,13 @@ occupancy because of the linear hash, which we now report explicitly instead of
 `0.000`. This keeps memory usage predictable without the specialized node
 formats used by ART.
 
-PATCH nodes maintain a rolling hash which allows efficient union, intersection and difference operations over whole subtrees.
+## Hash maintenance
+
+Each node maintains a 256‑bit rolling hash derived from the keys in its
+subtree. On insert or delete the old influence of a child is XORed out and the
+new one XORed in, yielding an updated hash in constant time. These hashes allow
+set operations such as union, intersection and difference to skip entire
+branches when the hashes differ.
+ 
 Keys can be viewed in different orders with the [`KeyOrdering`](../../src/patch.rs) trait and segmented via [`KeySegmentation`](../../src/patch.rs) to enable prefix based queries.
 All updates use copy‑on‑write semantics, so cloning a tree is cheap and safe.

--- a/book/src/deep-dive/trible-structure.md
+++ b/book/src/deep-dive/trible-structure.md
@@ -10,6 +10,44 @@ Instance of `Trible`s are stored in `TribleSet`s which index the trible in vario
 ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─▶
 ```
 
+On a high level, a trible is a triple consisting of an entity, an attribute,
+and a value. The entity and attribute are both 128‑bit abstract extrinsic
+identifiers as described in [crate::id], while the value is an arbitrary
+256‑bit [crate::value::Value]. The width of the value is chosen so that it can
+hold an entire intrinsic identifier, allowing larger payloads to be referenced
+via blobs without inflating the inlined representation.
+
+## Abstract identifiers
+
+Entities and attributes are purely extrinsic; their identifiers do not encode
+any meaning beyond uniqueness. An entity may accrue additional tribles over
+time and attributes simply name relationships without prescribing a schema.
+This keeps the format agnostic to external ontologies and minimises accidental
+coupling between datasets.
+
+The value slot can carry any 256‑bit payload. Its size is dictated by the need
+to embed an intrinsic identifier for out‑of‑line data. When a fact exceeds this
+space the value typically stores a blob handle pointing to the larger payload.
+
+Tribles are stored as a contiguous 64‑byte array with the entity occupying the
+first 16 bytes, the attribute the next 16 and the value the final 32 bytes. The
+name "trible" is a portmanteau of *triple* and *byte* and is pronounced like
+"tribble" from Star Trek – hence the project's mascot, Robert the tribble.
+
+## Advantages
+
+- A total order over tribles enables efficient storage and canonicalisation.
+- Simple byte‑wise segmentation supports indexing and querying without an
+  interning mechanism, keeping memory usage low and parallelisation easy while
+  avoiding the need for garbage collection.
+- Schemas describe the value portion directly, making serialisation and
+  deserialisation straightforward.
+- The fixed 64‑byte layout makes it easy to estimate the physical size of a
+  dataset as a function of the number of tribles stored.
+- The minimalistic design aims to minimise entropy while retaining collision
+  resistance, making it likely that a similar format would emerge through
+  convergent evolution and could serve as a universal data interchange format.
+
 # Direction and Consistency
 
 In other triple stores the direction of the edge drawn by a triple is often

--- a/book/src/pile-format.md
+++ b/book/src/pile-format.md
@@ -1,6 +1,6 @@
 # Pile Format
 
-The on-disk pile keeps every blob and branch in one append-only file. This layout provides a simple **write-ahead log** style database where new data is only appended. It allows both blob and branch storage in a single file while remaining resilient to crashes. The pile file can be memory mapped for fast reads and is safely shared between threads.
+The on-disk pile keeps every blob and branch in one append-only file. This layout provides a simple **write-ahead log** style database where new data is only appended. It allows both blob and branch storage in a single file while remaining resilient to crashes. The pile backs local repositories and acts as a durable content‑addressed store. The pile file can be memory mapped for fast reads and is safely shared between threads because existing bytes are never mutated.
 
 While large databases often avoid `mmap` due to pitfalls with partial writes
 and page cache thrashing [[1](https://db.cs.cmu.edu/mmap-cidr2022/)], this
@@ -23,6 +23,14 @@ pile is therefore fast while still catching corruption before data is used.
 Every record begins with a 16&nbsp;byte magic marker that identifies whether it
 stores a blob or a branch. The sections below illustrate the layout of each
 type.
+
+## Usage
+
+A pile typically lives as a `.pile` file on disk. Repositories open it through
+`Pile::open` which performs any necessary recovery and returns a handle for
+appending new blobs or branches. Multiple threads may share the same handle
+thanks to internal synchronisation, making a pile a convenient durable store for
+local development.
 ## Blob Storage
 ```
                              8 byte  8 byte

--- a/book/src/schemas.md
+++ b/book/src/schemas.md
@@ -10,6 +10,27 @@ what's already stored. The crate ships with a collection of ready‑made schemas
 [`src/value/schemas`](../src/value/schemas) and
 [`src/blob/schemas`](../src/blob/schemas).
 
+### Why 32 bytes?
+
+Storing arbitrary Rust types requires a portable representation. Instead of
+human‑readable identifiers like RDF's URIs, Tribles uses a fixed 32‑byte array
+for all values. This size provides enough entropy to embed intrinsic
+identifiers—typically cryptographic hashes—when a value references data stored
+elsewhere in a blob. Keeping the width constant avoids platform‑specific
+encoding concerns and makes it easy to reason about memory usage.
+
+### Conversion traits
+
+Schemas define how to convert between raw bytes and concrete Rust types. The
+conversion traits `ToValue`/`FromValue` and their fallible counterparts live on
+the schema types rather than on `Value` itself, avoiding orphan‑rule issues when
+supporting external data types. The `Value` wrapper treats its bytes as opaque;
+schemas may validate them or reject invalid patterns during conversion.
+
+Every schema declares a unique identifier such as `VALUE_SCHEMA_ID` (and
+optionally `BLOB_SCHEMA_ID` for blob handles). These IDs let applications store
+metadata about schemas in the graph and look them up at runtime.
+
 ## Built‑in value schemas
 
 The crate provides the following value schemas out of the box:

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,58 +1,8 @@
 //! Anything that can be represented as a byte sequence.
 //!
-//! A blob is a immutable sequence of bytes that can be used to represent any kind of data.
-//! It is the fundamental building block of data storage and transmission.
-//! The `BlobSchema` trait is used to define the abstract schema type of a blob.
-//! This is similar to the `Value` type and the `ValueSchema` trait in the [`value`](crate::value) module.
-//!
-//! But while values (and tribles) are used "in the small" to represent individual data items,
-//! blobs are used "in the large" to represent larger data structures like files, images, videos, etc.,
-//! collections of data items, or even entire databases.
-//!
-//! # Example
-//!
-//! ```
-//! use tribles::prelude::*;
-//! use tribles::examples::literature;
-//! use tribles::repo::repo;
-//! use valueschemas::{Handle, Blake3};
-//! use blobschemas::{SimpleArchive, LongString};
-//! use rand::rngs::OsRng;
-//! use ed25519_dalek::{Signature, Signer, SigningKey};
-//!
-//! // Let's build a BlobSet and fill it with some data.
-//! // Note that we are using the Blake3 hash protocol here.
-//! let mut memory_store: MemoryBlobStore<Blake3> = MemoryBlobStore::new();
-//!
-//! let book_author_id = fucid();
-//! let quote_a: Value<Handle<Blake3, LongString>> = memory_store.put("Deep in the human unconscious is a pervasive need for a logical universe that makes sense. But the real universe is always one step beyond logic.").unwrap();
-//! // Note how the type is inferred from it's usage in the [entity!](crate::namespace::entity!) macro.
-//! let quote_b = memory_store.put("I must not fear. Fear is the mind-killer. Fear is the little-death that brings total obliteration. I will face my fear. I will permit it to pass over me and
-//!  through me. And when it has gone past I will turn the inner eye to see its path. Where the fear has gone there will be nothing. Only I will remain.").unwrap();
-//!
-//! let set = literature::entity!({
-//!    title: "Dune",
-//!    author: &book_author_id,
-//!    quote: quote_a,
-//!    quote: quote_b
-//! });
-//!
-//! // Now we can serialize the TribleSet and store it in the BlobSet too.
-//! let archived_set_handle: Value<Handle<Blake3, SimpleArchive>> = memory_store.put(&set).unwrap();
-//!
-//! let mut csprng = OsRng;
-//! let commit_author_key: SigningKey = SigningKey::generate(&mut csprng);
-//! let signature: Signature = commit_author_key.sign(&memory_store.reader().get::<Blob<SimpleArchive>, SimpleArchive>(archived_set_handle).unwrap().bytes);
-//!
-//! // And store the handle in another TribleSet.
-//! let meta_set = repo::entity!({
-//!    content: archived_set_handle,
-//!    short_message: "Initial commit",
-//!    signed_by: commit_author_key.verifying_key(),
-//!    signature_r: signature,
-//!    signature_s: signature,
-//! });
-//! ```
+//! Blobs store larger data items outside tribles and values. For the design
+//! rationale and an extended usage example see the [Blobs
+//! chapter](../book/src/deep-dive/blobs.md) of the Tribles Book.
 
 // Converting Rust types to blobs is infallible in practice, so only `ToBlob`
 // and `TryFromBlob` are used throughout the codebase.  `TryToBlob` and

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,10 +1,8 @@
-//! # Persistent Adaptive Trie with Cuckoo-compression and Hash-maintenance
+//! Persistent Adaptive Trie with Cuckoo-compression and
+//! Hash-maintenance (PATCH).
 //!
-//! The PATCH is a novel adaptive trie, that uses cuckoo hashing
-//! as a node compression technique to store between 2 and 256
-//! children wide nodes with a single node type.
-//! It further uses efficient hash maintenance to provide fast
-//! set operations over these tries.
+//! See the [PATCH](../book/src/deep-dive/patch.md) chapter of the Tribles Book
+//! for the full design description and hashing scheme.
 //!
 #![allow(unstable_name_collisions)]
 
@@ -1210,13 +1208,13 @@ impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Iterator for PATCHIterat
     }
 }
 
-impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
-    ExactSizeIterator for PATCHIterator<'a, KEY_LEN, O, S>
+impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> ExactSizeIterator
+    for PATCHIterator<'a, KEY_LEN, O>
 {
 }
 
-impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
-    std::iter::FusedIterator for PATCHIterator<'a, KEY_LEN, O, S>
+impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> std::iter::FusedIterator
+    for PATCHIterator<'a, KEY_LEN, O>
 {
 }
 
@@ -1224,7 +1222,7 @@ impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_L
 /// The keys are returned in tree ordering and in tree order.
 pub struct PATCHOrderedIterator<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> {
     stack: Vec<ArrayVec<&'a Head<KEY_LEN, O>, 256>>,
-    remaining: usize
+    remaining: usize,
 }
 
 impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> PATCHOrderedIterator<'a, KEY_LEN, O> {
@@ -1295,13 +1293,13 @@ impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> Iterator
     }
 }
 
-impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
-    ExactSizeIterator for PATCHOrderedIterator<'a, KEY_LEN, O, S>
+impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> ExactSizeIterator
+    for PATCHOrderedIterator<'a, KEY_LEN, O>
 {
 }
 
-impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>, S: KeySegmentation<KEY_LEN>>
-    std::iter::FusedIterator for PATCHOrderedIterator<'a, KEY_LEN, O, S>
+impl<'a, const KEY_LEN: usize, O: KeyOrdering<KEY_LEN>> std::iter::FusedIterator
+    for PATCHOrderedIterator<'a, KEY_LEN, O>
 {
 }
 

--- a/src/trible.rs
+++ b/src/trible.rs
@@ -34,54 +34,12 @@ pub const V_END: usize = 63;
 /// Fundamentally a trible is always a collection of 64 bytes.
 pub type RawTrible = [u8; TRIBLE_LEN];
 
-/// The trible is the fundamental unit of storage in the knowledge graph,
-/// and is stored in [crate::trible::TribleSet]s which index the trible in various ways,
-/// allowing for efficient querying and retrieval of data.
+/// Fundamental 64-byte tuple of entity, attribute and value used throughout the
+/// knowledge graph.
 ///
-/// ``` text
-/// ┌────────────────────────────64 byte───────────────────────────┐
-/// ┌──────────────┐┌──────────────┐┌──────────────────────────────┐
-/// │  entity-id   ││ attribute-id ││        inlined value         │
-/// └──────────────┘└──────────────┘└──────────────────────────────┘
-/// └────16 byte───┘└────16 byte───┘└────────────32 byte───────────┘
-/// ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─▶
-/// ```
-///
-/// On a high level, a trible is a triple consisting of an entity, an attribute, and a value.
-/// The entity and attribute are both 128-bit abstract extrinsic identifiers as described in [crate::id],
-/// while the value is an arbitrary 256-bit [crate::value::Value].
-/// The design of tribles is influenced by the need to minimize entropy while ensuring collision resistance.
-/// Entities are abstract because they might have additional facts associated with them in the form of new tribles.
-/// Similarly, attributes are abstract because their meaning is inherently non-grounded; the meaning of the "symbol" is only
-/// the meaning ascribed to it, without any natural meaning.
-/// Values can be any data that fits "inlined" into the fixed width, and they need to be large enough to hold an intrinsic
-/// identifier for larger data. As established in the `id` module documentation, these need to be at least 256 bits / 32 bytes.
-/// Counter-intuitively, their size and thus the size of "inline" data is determined by the scenario where data is too large
-/// to be inlined. See [blob](crate::blob)s for a way to store larger data.
-///
-/// The trible is stored as a contiguous 64-byte array, with the entity taking the first 16 bytes,
-/// the attribute taking the next 16 bytes, and the value taking the last 32 bytes.
-///
-/// The name trible is a portmanteau of triple and byte, and is pronounced like "tribble" from Star Trek.
-/// This is also the reason why the mascot of the knowledge graph is Robert the tribble.
-///
-/// The minimalistic design of the trible has a number of advantages:
-/// - It is very easy to define an order on tribles, which allows for efficient storage
-///   and easy canonicalization of data.
-/// - It is very easy to define a segmentation on tribles, which allows for efficient
-///   indexing and querying of data, without then need for an interning mechanism,
-///   that translates values to an internal integer representation. This simplifies
-///   the implementation, saves memory and an additional lookup, prevents the single
-///   registry from becoming a bottleneck, allowing for easy parallelization, and
-///   obviates the need for a garbage collection mechanism.
-/// - It is very easy to define a schema for the value, which allows for efficient
-///   serialization and deserialization of data.
-/// - On a high level, it is very easy to reason about the data stored in the knowledge graph.
-///   Additionally, it is possible to estimate the physical size of the data stored in the knowledge graph
-///   in terms of the number of bytes, as a function of the number of tribles stored.
-/// - Due to the fundamental principles of minimizing entropy and ensuring collision resistance, it is likely that this format
-///   will be independently discovered through convergent evolution, making it a strong candidate for a universal data interchange format.
-///   And who knows, it might even be useful if we ever make contact with extra-terrestrial intelligences!
+/// See the [Trible Structure](../book/src/deep-dive/trible-structure.md)
+/// chapter of the Tribles Book for a detailed discussion of the layout and its
+/// design rationale.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
 #[repr(transparent)]
 pub struct Trible {


### PR DESCRIPTION
## Summary
- port remaining rationale from blob, patch, pile and schema modules into dedicated book chapters
- add sections on abstract identifiers in trible structure, rolling hashes in PATCH, pile usage and value conversion traits
- note these expansions in the changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68953735609883229fb6a135708b205b