### PR TITLE
docs: clarify trible permutations and shared leaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Git-based terminology notes in the repository guide and a clearer workspace example.
 - Expanded the repository example to store actual data and simplified the conflict loop.
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
+- Diagram and explanation of six trible permutations and shared leaves for skew‑resistant joins.
 ### Changed
 - PATCH infix and segment-length operations now require prefixes to align with
   segment boundaries.

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -20,6 +20,11 @@ The fundamental unit of information is a [`Trible`](https://docs.rs/tribles/late
 
 `TribleSet`s provide fast querying and cheap copy‑on‑write semantics.  They can be merged, diffed and searched entirely in memory.  When durability is needed the set is serialised into a blob and tracked by the repository layer.
 
+To keep joins skew‑resistant, each set maintains all six orderings of entity,
+attribute and value.  The trees reuse the same leaf nodes so a trible is stored
+only once, avoiding a naïve six‑fold memory cost while still letting the query
+planner pick the most selective permutation.
+
 ## Blob Storage
 
 All persistent data lives in a [`BlobStore`](https://docs.rs/tribles/latest/tribles/blob/index.html).  Every blob is addressed by the hash of its contents.  This content addressing means the same data is never stored twice and its integrity can be verified on read.  Different implementations handle where bytes actually reside: an in‑memory [`MemoryBlobStore`](https://docs.rs/tribles/latest/tribles/blob/struct.MemoryBlobStore.html), an on‑disk [`Pile`](https://docs.rs/tribles/latest/tribles/repo/pile/struct.Pile.html) described in [Pile Format](pile-format.md) or a remote object store.  Trible sets, user blobs and commit records all share this mechanism.

--- a/book/src/deep-dive/trible-structure.md
+++ b/book/src/deep-dive/trible-structure.md
@@ -34,6 +34,34 @@ first 16 bytes, the attribute the next 16 and the value the final 32 bytes. The
 name "trible" is a portmanteau of *triple* and *byte* and is pronounced like
 "tribble" from Star Trek – hence the project's mascot, Robert the tribble.
 
+## Index permutations
+
+`TribleSet`s index each fact under all six permutations of entity (E), attribute
+(A) and value (V) so any combination of bound variables can be resolved
+efficiently:
+
+```text
+┌─────┐  ┌─────┐  ┌─────┐  ┌─────┐  ┌─────┐  ┌─────┐
+│ EAV │  │ EVA │  │ AEV │  │ AVE │  │ VEA │  │ VAE │
+└──┬──┘  └──┬──┘  └──┬──┘  └──┬──┘  └──┬──┘  └──┬──┘
+   │        │        │        │        │        │
+┌───────────────────────────────────────────────────────┐
+│            order-specific inner nodes                 │
+└───────────────────────────────────────────────────────┘ 
+   │        │        │        │        │        │
+   ▼        ▼        ▼        ▼        ▼        ▼
+
+┌───────────────────────────────────────────────────────┐
+│                   SHARED LEAVES                       │
+│     single canonical E–A–V tribles used by all        │
+└───────────────────────────────────────────────────────┘
+```
+
+Each permutation has its own inner nodes, but all six share leaf nodes
+containing the 64‑byte trible. This avoids a naïve six‑fold memory cost while
+still letting the query planner pick the most selective ordering, keeping joins
+resistant to skew.
+
 ## Advantages
 
 - A total order over tribles enables efficient storage and canonicalisation.


### PR DESCRIPTION
## Summary
- document six entity-attribute-value permutations with shared leaves
- highlight skew-resistant joins in architecture overview
- note the addition in changelog
- refine the permutations diagram to show order-specific inner nodes and shared leaves

## Testing
- `./scripts/devtest.sh`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896242af61c8322b8b6bf78ef0c9a86