### PR TITLE
docs: document implemented commit selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now tracked in this changelog.
 - Canonicalized epsilon closures in regular path queries and documented the
   Thompson-style automaton construction.
+- Documented the currently implemented commit selectors in the book.
 
 ### Fixed
 - Enforce `PREFIX_LEN <= KEY_LEN` for prefix checks in PATCH.


### PR DESCRIPTION
## Summary
- list implemented commit selectors in the book
- mark commit handle selectors as implemented

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68964e7135d883228ef8d67689934ba1