### PR TITLE
feat: add nth ancestor commit selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `nth_ancestor` commit selector corresponding to Git's `A~N` syntax and
+  documentation updates.
 - `INVENTORY.md` file and instructions for recording future work.
 - README now links to the corresponding chapters on https://triblespace.github.io/tribles-rust.
 - `branch_id_by_name` helper to resolve branch IDs from names. Returns a

--- a/book/src/commit-selectors.md
+++ b/book/src/commit-selectors.md
@@ -18,6 +18,7 @@ the start is omitted, `a` defaults to the empty set so `..b` simply yields
 - `CommitHandle` – a single commit.
 - `Vec<CommitHandle>` and `&[CommitHandle]` – explicit lists of commits.
 - `ancestors(commit)` – a commit and all of its ancestors.
+- `nth_ancestor(commit, n)` – follows the first-parent chain `n` steps.
 - `symmetric_diff(a, b)` – commits reachable from either `a` or `b` but not
   both.
 - Standard ranges: `a..b`, `a..`, `..b` and `..` following the two‑dot
@@ -63,7 +64,7 @@ than commits are listed for completeness but are unlikely to be implemented.
 |-----------|-------------------|-----------|--------|
 | `A` | `commit(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#_specifying_revisions) | Implemented |
 | `A^`/`A^N` | `nth_parent(A, N)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revnegHEADv1510) | Not planned |
-| `A~N` | `nth_ancestor(A, N)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revnegHEADmaster3) | Unimplemented |
+| `A~N` | `nth_ancestor(A, N)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revnegHEADmaster3) | Implemented |
 | `A^@` | `parents(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revegHEAD) | Unimplemented |
 | `A^!` | `A minus parents(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revegHEAD-1) | Unimplemented |
 | `A^-N` | `A minus nth_parent(A, N)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-rev-negHEAD-HEAD-2) | Not planned |


### PR DESCRIPTION
## Summary
- implement `nth_ancestor` commit selector for first-parent history
- document selector and mark `A~N` as implemented
- test selector and note change in changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68967fdc97c08322b51dd567138aecb8