### PR TITLE
Document CALM reasoning and delta query examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation and examples for the repository API.
 - Test coverage for `branch_from` and `pull_with_key`.
 - `Workspace::checkout` helper to load commit contents.
+- Documentation and example for incremental queries using `pattern_changes!`
+  plus additional tests.
 - `pattern!` now implemented as a procedural macro in the new `tribles-macros` crate.
 - `entity!` now implemented as a procedural macro alongside `pattern!`.
 - `ThompsonEngine` implementing a new `PathEngine` trait for regular path queries,

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -5,6 +5,8 @@
 
 ## Desired Functionality
 - Provide additional examples showcasing advanced queries and repository usage.
+- Helper to derive delta `TribleSet`s for `pattern_changes!` so callers don't
+  have to compute them manually.
 - Explore replacing `CommitSelector` ranges with a set-based API
   built on commit reachability. The goal is to mirror git's revision
   selection semantics (similar to `rev-list` or `rev-parse`).

--- a/book/src/incremental-queries.md
+++ b/book/src/incremental-queries.md
@@ -2,33 +2,51 @@
 
 The query engine today evaluates against a static `TribleSet`. Many
 applications would rather compute just the new results when additional
-data arrives. We plan to support this using *semi‑naive evaluation*.
+data arrives. We support this using *semi‑naive evaluation*.
 
 When a dataset grows, we compute a delta set of the newly inserted
 tribles. For each triple constraint in the original query we evaluate a
-variant of the query where that single constraint is restricted to the
-delta while the remaining constraints see the full updated dataset. Each
-case yields the new solutions introduced by those additions and we then
-union all of the per‑constraint results.
+variant where only that constraint is restricted to the delta while the
+remaining constraints see the full updated dataset. Each case yields the
+new solutions introduced by those additions and we union all of the
+per‑constraint results.
 
-To help express these delta queries at the macro level, namespaces now
-offer a `pattern_changes!` operator. It behaves like `pattern!` but takes the
-current `TribleSet` and a precomputed changeset. The macro simply unions
-variants of the query where each triple is constrained to that changeset,
-matching only the newly inserted tribles. Combined with the
-union constraint, this lets us run incremental updates using the familiar
-`find!` interface.
+## Monotonicity and CALM
 
-We can reuse the existing `find!` interface to run these partial queries
-and poll for updates whenever an application receives a new `TribleSet`.
-This mechanism also lets us compute the difference between two arbitrary
-datasets by treating the change set as the delta.
+Removed results are not tracked. Tribles follow the [CALM
+principle](https://bloom-lang.net/calm/): a program whose outputs are
+monotonic in its inputs needs no coordination. Updates simply add new
+facts and previously derived conclusions remain valid. When conflicting
+information arises, applications append fresh tribles describing their
+preferred view instead of retracting old ones. Stores may forget obsolete
+data, but semantically tribles are never deleted.
 
-Removed results are not tracked. Tribles are designed to be monotonic
-(CALM); new facts never invalidate previous conclusions. Applications can
-represent contradictions explicitly and continue operating by appending
-new tribles that reference the view they choose to follow.
+## Example
 
-Semantically this means tribles are never deleted, though individual
-stores may forget them. Old data remains valid even if it becomes
-inaccessible.
+Namespaces provide a `pattern_changes!` operator to express these delta
+queries. It behaves like `pattern!` but takes the current `TribleSet` and
+a precomputed changeset. The macro unions variants of the query where
+each triple is constrained to that changeset, matching only the newly
+inserted tribles. Combined with the union constraint, this lets us run
+incremental updates using the familiar `find!` interface.
+
+```rust
+{{#include ../../examples/pattern_changes.rs:pattern_changes_example}}
+```
+
+## Comparing history points
+
+`Workspace::checkout` accepts [commit selectors](commit-selectors.md)
+which can describe ranges in repository history. By checking out a
+range like `a..b` we obtain exactly the tribles introduced by commits
+reachable from `b` but not from `a`. Feeding that delta into
+`pattern_changes!` lets us ask, “What new matches did commit `b`
+introduce over `a`?”
+
+## Trade‑offs
+
+- Applications must compute and supply the delta set; the engine does not
+  track changes automatically.
+- Queries must remain monotonic since deletions are ignored.
+- Each triple incurs an extra variant, so highly selective constraints
+  keep incremental evaluation efficient.

--- a/examples/pattern_changes.rs
+++ b/examples/pattern_changes.rs
@@ -1,0 +1,57 @@
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use tribles::prelude::valueschemas::*;
+use tribles::prelude::*;
+use tribles::repo::memoryrepo::MemoryRepo;
+use tribles::repo::Repository;
+
+NS! {
+    pub namespace literature {
+        "8F180883F9FD5F787E9E0AF0DF5866B9" as author: GenId;
+        "0DBB530B37B966D137C50B943700EDB2" as firstname: ShortString;
+        "6BAA463FD4EAF45F6A103DB9433E4545" as lastname: ShortString;
+        "A74AA63539354CDA47F387A4C3A8D54C" as title: ShortString;
+    }
+}
+
+fn main() {
+    // ANCHOR: pattern_changes_example
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+    let mut ws = repo.branch("main").expect("branch");
+
+    // Commit initial data
+    let shakespeare = ufoid();
+    let hamlet = ufoid();
+    let mut base = TribleSet::new();
+    base += literature::entity!(&shakespeare, { firstname: "William", lastname: "Shakespeare" });
+    base += literature::entity!(&hamlet, { title: "Hamlet", author: &shakespeare });
+    ws.commit(base.clone(), None);
+    let c1 = ws.head().unwrap();
+
+    // Commit a new book
+    let macbeth = ufoid();
+    let mut change = TribleSet::new();
+    change += literature::entity!(&macbeth, { title: "Macbeth", author: &shakespeare });
+    ws.commit(change.clone(), None);
+    let c2 = ws.head().unwrap();
+
+    // Compute updated state and delta between commits
+    let base_state = ws.checkout(c1).expect("base");
+    let updated = ws.checkout(c2).expect("updated");
+    let delta = updated.difference(&base_state);
+
+    // Find new titles by Shakespeare
+    let results: Vec<_> = find!(
+        (author: Value<_>, book: Value<_>, title: Value<_>),
+        literature::pattern_changes!(&updated, &delta, [
+            { author @ firstname: ("William"), lastname: ("Shakespeare") },
+            { book @ author: author, title: title }
+        ])
+    )
+    .map(|(_, b, t)| (b, t))
+    .collect();
+
+    println!("{results:?}");
+    // ANCHOR_END: pattern_changes_example
+}

--- a/tests/pattern_changes.rs
+++ b/tests/pattern_changes.rs
@@ -1,0 +1,61 @@
+use tribles::prelude::valueschemas::*;
+use tribles::prelude::*;
+
+NS! {
+    pub namespace literature {
+        "8F180883F9FD5F787E9E0AF0DF5866B9" as author: GenId;
+        "0DBB530B37B966D137C50B943700EDB2" as firstname: ShortString;
+        "6BAA463FD4EAF45F6A103DB9433E4545" as lastname: ShortString;
+        "A74AA63539354CDA47F387A4C3A8D54C" as title: ShortString;
+    }
+}
+
+#[test]
+fn pattern_changes_finds_new_inserts() {
+    let base = TribleSet::new();
+
+    let mut updated = base.clone();
+    let shakespeare = ufoid();
+    let hamlet = ufoid();
+    updated += literature::entity!(&shakespeare, { firstname: "William", lastname: "Shakespeare" });
+    updated += literature::entity!(&hamlet, { title: "Hamlet", author: &shakespeare });
+
+    let delta = updated.difference(&base);
+
+    let results: Vec<_> = find!(
+        (author: Value<_>, book: Value<_>, title: Value<_>),
+        literature::pattern_changes!(&updated, &delta, [
+            { author @ firstname: ("William"), lastname: ("Shakespeare") },
+            { book @ author: author, title: title }
+        ])
+    )
+    .collect();
+
+    assert_eq!(
+        results,
+        vec![(
+            shakespeare.to_value(),
+            hamlet.to_value(),
+            "Hamlet".to_value(),
+        )]
+    );
+}
+
+#[test]
+fn pattern_changes_empty_delta_returns_no_matches() {
+    let mut kb = TribleSet::new();
+    let shakespeare = ufoid();
+    kb += literature::entity!(&shakespeare, { firstname: "William", lastname: "Shakespeare" });
+
+    let delta = TribleSet::new();
+
+    let results: Vec<_> = find!(
+        (a: Value<_>),
+        literature::pattern_changes!(&kb, &delta, [
+            { a @ lastname: ("Shakespeare") }
+        ])
+    )
+    .collect();
+
+    assert!(results.is_empty());
+}


### PR DESCRIPTION
## Summary
- Explain CALM-based monotonicity and trade-offs of incremental queries
- Add example and book snippet for `pattern_changes!` using commit selectors
- Add tests covering `pattern_changes!`

## Testing
- `cargo test`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68967d940a48832283ec3bf1fba94667