### PR TITLE
feat: add parents commit selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `nth_ancestor` commit selector corresponding to Git's `A~N` syntax and
   documentation updates.
+- `parents` commit selector corresponding to Git's `A^@` syntax.
 - `INVENTORY.md` file and instructions for recording future work.
 - README now links to the corresponding chapters on https://triblespace.github.io/tribles-rust.
 - `branch_id_by_name` helper to resolve branch IDs from names. Returns a

--- a/book/src/commit-selectors.md
+++ b/book/src/commit-selectors.md
@@ -19,6 +19,7 @@ the start is omitted, `a` defaults to the empty set so `..b` simply yields
 - `Vec<CommitHandle>` and `&[CommitHandle]` – explicit lists of commits.
 - `ancestors(commit)` – a commit and all of its ancestors.
 - `nth_ancestor(commit, n)` – follows the first-parent chain `n` steps.
+- `parents(commit)` – direct parents of a commit.
 - `symmetric_diff(a, b)` – commits reachable from either `a` or `b` but not
   both.
 - Standard ranges: `a..b`, `a..`, `..b` and `..` following the two‑dot
@@ -65,7 +66,7 @@ than commits are listed for completeness but are unlikely to be implemented.
 | `A` | `commit(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#_specifying_revisions) | Implemented |
 | `A^`/`A^N` | `nth_parent(A, N)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revnegHEADv1510) | Not planned |
 | `A~N` | `nth_ancestor(A, N)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revnegHEADmaster3) | Implemented |
-| `A^@` | `parents(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revegHEAD) | Unimplemented |
+| `A^@` | `parents(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revegHEAD) | Implemented |
 | `A^!` | `A minus parents(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revegHEAD-1) | Unimplemented |
 | `A^-N` | `A minus nth_parent(A, N)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-rev-negHEAD-HEAD-2) | Not planned |
 | `A^0` | `commit(A)` | [gitrevisions](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-revnegHEADv1510) | Implemented |

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -2,7 +2,8 @@ use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::prelude::*;
 use tribles::repo::{
-    ancestors, history_of, memoryrepo::MemoryRepo, nth_ancestor, symmetric_diff, Repository,
+    ancestors, history_of, memoryrepo::MemoryRepo, nth_ancestor, parents, symmetric_diff,
+    Repository,
 };
 
 #[test]
@@ -266,6 +267,58 @@ fn workspace_nth_ancestor_selector() {
         .checkout(nth_ancestor(head, 3))
         .expect("checkout past root");
     assert_eq!(empty.len(), 0);
+}
+
+#[test]
+fn workspace_parents_selector() {
+    use tribles::value::schemas::r256::R256;
+
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+
+    // Base commit so both workspaces share a common ancestor.
+    let mut ws_main = repo.branch("main").expect("create branch");
+    let e0 = ufoid();
+    let a0 = ufoid();
+    let v0: Value<R256> = 0i128.to_value();
+    let t0 = Trible::new(&e0, &a0, &v0);
+    let mut s0 = TribleSet::new();
+    s0.insert(&t0);
+    ws_main.commit(s0, None);
+    repo.push(&mut ws_main).expect("push base");
+
+    // Fork a second workspace from the same base commit.
+    let mut ws_feature = repo.pull(ws_main.branch_id()).expect("pull branch state");
+
+    // Divergent commits on both workspaces.
+    let e1 = ufoid();
+    let a1 = ufoid();
+    let v1: Value<R256> = 1i128.to_value();
+    let t1 = Trible::new(&e1, &a1, &v1);
+    let mut s1 = TribleSet::new();
+    s1.insert(&t1);
+    ws_main.commit(s1.clone(), None);
+
+    let e2 = ufoid();
+    let a2 = ufoid();
+    let v2: Value<R256> = 2i128.to_value();
+    let t2 = Trible::new(&e2, &a2, &v2);
+    let mut s2 = TribleSet::new();
+    s2.insert(&t2);
+    ws_feature.commit(s2.clone(), None);
+
+    // Merge the feature workspace into main to create a commit with two parents.
+    ws_main.merge(&mut ws_feature).expect("merge workspaces");
+    let merge_commit = ws_main.head().expect("merge head");
+
+    let result = ws_main
+        .checkout(parents(merge_commit))
+        .expect("checkout parents");
+
+    let mut expected = s1;
+    expected.union(s2);
+
+    assert_eq!(result, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- implement `parents` commit selector and helper
- document and test the parents selector

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68968513d48c83229e23cd6421d68e10