### PR TITLE
Add glossary chapter to Tribles book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Glossary chapter in the book for quick reference to core terminology.
 - `nth_ancestor` commit selector corresponding to Git's `A~N` syntax and
   documentation updates.
 - `parents` commit selector corresponding to Git's `A^@` syntax.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -79,6 +79,7 @@ prioritized for efficient zero-copy access.
   into the book.
 - Split out the lengthy explanation of trible structure from `src/trible.rs`
   and consolidate it with the deep dive chapter.
+- Add a FAQ chapter to the book summarising common questions.
 
 ## Discovered Issues
 - No open issues recorded yet.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,6 +12,7 @@
 - [Repository Workflows](repository-workflows.md)
 - [Commit Selectors](commit-selectors.md)
 - [Garbage Collection](garbage-collection.md)
+- [Glossary](glossary.md)
 - [Deep Dive](deep-dive/README.md)
   - [Philosophy](deep-dive/philosophy.md)
   - [Identifiers](deep-dive/identifiers.md)

--- a/book/src/glossary.md
+++ b/book/src/glossary.md
@@ -1,0 +1,20 @@
+# Glossary
+
+**Blob**: A chunk of binary data addressed by the hash of its contents. Blobs are
+immutable and can live in memory, on disk, or in remote object stores.
+
+**Trible**: A three-part tuple of entity, attribute, and value. Tribles are the
+atomic facts that make up all higher level structures in Trible Space.
+
+**Trible Space**: The overall storage model that organises tribles across blobs,
+PATCHes, and repositories. It emphasises immutability and content addressing.
+
+**PATCH**: A tree-shaped index used to organise tribles for efficient queries.
+Different permutations of the same trible share leaves to resist skewed data.
+
+**Pile**: An append-only collection of blobs such as tribles, patches, and other
+data. Piles can be opened from local files or object stores.
+
+**Workspace**: A mutable working area for preparing commits. Once a commit is
+finalised, it becomes immutable like the rest of Trible Space.
+

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -12,6 +12,7 @@ enable efficient sharing across systems.
 
 While this book walks you through the basics, the crate documentation offers a
 complete API reference. Use the links throughout the text to jump directly to
-the modules that interest you.
+the modules that interest you. A [Glossary](glossary.md) is provided for quick
+reference to common terms.
 
 If you would like to work on Tribles yourself, check out [Developing Locally](contributing.md).


### PR DESCRIPTION
## Summary
- Add a new Glossary chapter with definitions of key Trible Space concepts
- Reference the Glossary from the introduction and table of contents
- Record the addition in the changelog and inventory

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68969b0226448322adc130c66d39f7f6