### PR TITLE
docs: expand getting started guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 - Diagram and explanation of six trible permutations and shared leaves for skew‑resistant joins.
 ### Changed
+- Expanded the "Getting Started" book section with dependency setup and run instructions.
 - PATCH infix and segment-length operations now require prefixes to align with
   segment boundaries.
 - `KeyOrdering` and `KeySegmentation` now expose translation tables as associated const arrays instead of methods.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -1,10 +1,12 @@
 # Getting Started
 
-First add the crate to your project:
+First add the required crates to your project:
 
 ```bash
-cargo add tribles
+cargo add tribles ed25519-dalek rand
 ```
+
+This example uses `ed25519-dalek` to generate a signing key and `rand` for randomness.
 
 Next create a simple repository and commit some data:
 
@@ -28,6 +30,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+Running this program with `cargo run` creates an `example.pile` file in the current
+directory and pushes a single entity to the `main` branch.
 
 See the [crate documentation](https://docs.rs/tribles/latest/tribles/) for
 additional modules and examples.


### PR DESCRIPTION
## Summary
- document required `ed25519-dalek` and `rand` dependencies and note that running the example creates an `example.pile`
- add changelog entry for the Getting Started section update

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68969b542b34832295c7c8c7a8be384f