### PR TITLE
docs: expand local development guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 - Diagram and explanation of six trible permutations and shared leaves for skew‑resistant joins.
 ### Changed
+- Expanded the "Developing Locally" book chapter with guidance on helper scripts and local setup.
 - PATCH infix and segment-length operations now require prefixes to align with
   segment boundaries.
 - `KeyOrdering` and `KeySegmentation` now expose translation tables as associated const arrays instead of methods.

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -2,6 +2,10 @@
 
 To build and test Tribles yourself you need a recent Rust toolchain. Install it from [rustup.rs](https://rustup.rs/).
 
-Run `./scripts/preflight.sh` from the repository root to format the code and execute the full test suite. For quick iterations `./scripts/devtest.sh` runs only the tests.
+The repository provides helper scripts for common workflows:
 
-If you want to render this book locally first install `mdbook` with `cargo install mdbook` and then run `./scripts/build_book.sh`.
+- `./scripts/preflight.sh` formats the code, runs the full test suite and rebuilds this book. Run it before committing.
+- `./scripts/devtest.sh` executes only the tests for faster feedback during development.
+- `./scripts/build_book.sh` rebuilds the documentation once [`mdbook`](https://rust-lang.github.io/mdBook/) is installed with `cargo install mdbook`.
+
+These scripts keep the project formatted, tested and documented while you iterate locally.


### PR DESCRIPTION
## Summary
- expand "Developing Locally" chapter with helper script guidance
- note documentation change in changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68969b580f888322afa97b42c0b10917