### PR TITLE
docs: expand Atreides Join chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 - Diagram and explanation of six trible permutations and shared leaves for skew‑resistant joins.
 ### Changed
+- Expanded the Atreides Join chapter with an example, clearer algorithm explanations, and a note that random access remains only for confirming candidates.
+- Rephrased Atreides Join discussion of sorted indexes to highlight efficient value lookup.
+- Gave each Atreides join variant a descriptive name alongside its Dune nickname.
 - PATCH infix and segment-length operations now require prefixes to align with
   segment boundaries.
 - `KeyOrdering` and `KeySegmentation` now expose translation tables as associated const arrays instead of methods.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -71,6 +71,7 @@ Formats with solid memory-mapping support in the Rust ecosystem should be
 prioritized for efficient zero-copy access.
 
 ## Documentation
+- Add diagrams or pseudocode to the Atreides Join chapter illustrating variable selection and search.
 - Move the "Portability & Common Formats" overview from `src/value.rs` into a
   dedicated chapter of the book.
 - Migrate the blob module introduction in `src/blob.rs` so the crate docs focus


### PR DESCRIPTION
## Summary
- clarify Atreides join algorithms and add example query
- note future Atreides join documentation in inventory
- log documentation update in changelog
- elaborate on how cardinality bounds replace random index lookups and that random access remains for confirmation
- rephrase sorted index explanation to emphasize efficient value lookup
- give join variants descriptive names alongside their Dune nicknames

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68969b643c2083229f2542ebfee1ab13