### PR TITLE
Rename mask! macro to ignore!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Procedural `namespace!` macro replaces the declarative `NS!` implementation.
 - Implemented a procedural `delta!` macro for incremental query support.
 - Expanded documentation for the `pattern` procedural macro to ease maintenance, including detailed comments inside the implementation.
+- Expanded Query Language chapter with iterator examples and clarified that
+  `ignore!` skips variables so their constraints aren't checked, enabling
+  existential or don't-care matches.
 - `EntityId` variants renamed to `Var` and `Lit` for consistency with field patterns.
 - `Workspace::checkout` now accepts commit ranges for convenient history queries.
 - Git-based terminology notes in the repository guide and a clearer workspace example.
@@ -65,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 - Diagram and explanation of six trible permutations and shared leaves for skew‑resistant joins.
 ### Changed
+- Renamed `mask!` macro to `ignore!` for clarity.
 - PATCH infix and segment-length operations now require prefixes to align with
   segment boundaries.
 - `KeyOrdering` and `KeySegmentation` now expose translation tables as associated const arrays instead of methods.
@@ -89,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `nth_parent` commit selector and helper; parent-numbering is not planned.
 ### Fixed
+- `ignore!` now hides variables correctly by subtracting them from inner constraints.
 - ByteTable resize benchmark now reports load factor for fully populated 256-slot tables.
 - `PatchIdConstraint` incorrectly used 32-byte values when confirming IDs, causing
   `local_ids` queries to return no results with overridden estimates.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -5,6 +5,7 @@
 
 ## Desired Functionality
 - Provide additional examples showcasing advanced queries and repository usage.
+- Include a cross-namespace regular path query example in the book.
 - Helper to derive delta `TribleSet`s for `pattern_changes!` so callers don't
   have to compute them manually.
 - Explore replacing `CommitSelector` ranges with a set-based API

--- a/src/query.rs
+++ b/src/query.rs
@@ -14,8 +14,8 @@
 pub mod constantconstraint;
 pub mod hashmapconstraint;
 pub mod hashsetconstraint;
+pub mod ignore;
 pub mod intersectionconstraint;
-pub mod mask;
 pub mod patchconstraint;
 pub mod regularpathconstraint;
 pub mod unionconstraint;
@@ -28,7 +28,7 @@ use std::{fmt, usize};
 
 use arrayvec::ArrayVec;
 use constantconstraint::*;
-use mask::*;
+pub use ignore::IgnoreConstraint;
 
 use crate::value::{schemas::genid::GenId, RawValue, Value, ValueSchema};
 
@@ -603,6 +603,7 @@ pub use matches;
 mod tests {
     use valueschemas::ShortString;
 
+    use crate::ignore;
     use crate::prelude::valueschemas::*;
     use crate::prelude::*;
 
@@ -743,6 +744,22 @@ mod tests {
             (a: Value<_>),
             and!(a.is(I256BE::value_from(1)), a.is(I256BE::value_from(2)))
         ));
+    }
+
+    #[test]
+    fn ignore_skips_variables() {
+        let results: Vec<_> = find!(
+            (x: Value<_>),
+            ignore!(
+                __local_find_context!(),
+                (y),
+                and!(x.is(I256BE::value_from(1)), y.is(I256BE::value_from(2)))
+            )
+        )
+        .collect();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, I256BE::value_from(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- rename `mask!` macro to `ignore!` and update constraint type
- document `ignore!` usage and rationale in the query language chapter
- note the rename in the changelog and clean up inventory
- subtract ignored variables from inner constraints and cover with regression test

## Testing
- `cargo fmt`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68969b6975a08322a59107812c5adbde