### PR TITLE
docs: refine repository workflows chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 - Diagram and explanation of six trible permutations and shared leaves for skew‑resistant joins.
 ### Changed
+- Expanded repository workflows chapter with clearer branching steps and a
+  dedicated history section.
 - PATCH infix and segment-length operations now require prefixes to align with
   segment boundaries.
 - `KeyOrdering` and `KeySegmentation` now expose translation tables as associated const arrays instead of methods.


### PR DESCRIPTION
## Summary
- clarify repository terminology and typical branching steps
- add dedicated history inspection section and improved conflict explanation
- note documentation update in changelog

## Testing
- `cargo fmt`
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68969b7407808322ac3b1270fd9344cb