### PR TITLE
docs: expand commit selector filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded the repository example to store actual data and simplified the conflict loop.
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 - Diagram and explanation of six trible permutations and shared leaves for skew‑resistant joins.
+- Additional example in the Commit Selectors chapter demonstrating how to
+  compose `filter` with `time_range`.
 ### Changed
 - PATCH infix and segment-length operations now require prefixes to align with
   segment boundaries.

--- a/book/src/commit-selectors.md
+++ b/book/src/commit-selectors.md
@@ -47,9 +47,22 @@ commit sets without complicating the core API.
 
 The `filter` selector wraps another selector and keeps only the commits for
 which a user provided closure returns `true`. The closure receives the commit
-metadata and its payload. Higher level helpers can build on this primitive. For
-example `history_of(entity)` filters `ancestors(HEAD)` to commits touching a
-specific entity:
+metadata and its payload, allowing inspection of authors, timestamps or the
+data itself. Selectors compose, so you can further narrow a range:
+
+```rust
+use hifitime::Epoch;
+use tribles::repo::{filter, time_range};
+
+let since = Epoch::from_unix_seconds(1_609_459_200.0); // 2020-12-01
+let now = Epoch::now().unwrap();
+let recent = ws.checkout(filter(time_range(since, now), |_, payload| {
+    payload.iter().any(|t| t.e() == &my_entity)
+}))?;
+```
+
+Higher level helpers can build on this primitive. For example `history_of(entity)` filters
+`ancestors(HEAD)` to commits touching a specific entity:
 
 ```rust
 let changes = ws.checkout(history_of(my_entity))?;


### PR DESCRIPTION
## Summary
- demonstrate composing commit selectors by combining `filter` with `time_range`
- note the example in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68969b7702648322bc9e918ce3225486