### PR TITLE
Expand garbage collection chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified that accidental collisions are practically impossible given 32-byte
   hashes, explaining why the collector can treat any matching value as a real
   reference.
+- Expanded the book's garbage collection chapter with clearer reachability
+  description, traversal overview and handle-based pruning.
 - Repository workflows chapter covering branching, merging, CLI usage and an improved push/merge diagram.
 - Separate `verify.sh` script for running Kani verification.
 - Documented conflict resolution loop and clarified that returned workspaces

--- a/book/src/garbage-collection.md
+++ b/book/src/garbage-collection.md
@@ -1,48 +1,46 @@
 # Garbage Collection and Forgetting
 
-Repositories grow over time as new blobs are written for commits, branch
-metadata and user data.  Because each blob is content addressed there is no
-built‑in mechanism to reclaim space when branches move or objects become
-orphaned.  A repository may choose to _forget_ unreachable blobs to recover
-storage.  Forgetting does not violate TribleSpace's monotonic model – removed
-blobs can always be reintroduced if discovered again – but it requires a
-conservative reachability analysis to avoid discarding data still referenced by
-existing branches.
+Repositories grow over time as commits, branch metadata and user blobs
+accumulate. Because each blob is content addressed and immutable, nothing is
+ever overwritten and there is no automatic reclamation when branches move or
+objects become orphaned. To keep disk usage in check a repository can
+periodically _forget_ blobs that are no longer referenced. Forgetting only
+removes local copies; any blob can be reintroduced later without violating
+TribleSpace's monotonic model. The challenge is deciding which blobs are still
+reachable without rebuilding every record.
 
 ## Conservative Reachability
 
-Every commit and branch metadata record is stored as a `SimpleArchive`.  The
-format is a canonicalised `TribleSet` encoded as alternating 32‑byte keys and
-values.  When searching for references we do not rebuild the set.  Instead we
-scan the archive in 32‑byte chunks and treat every second segment as a candidate
-value.  Any segment that matches the hash of a blob in the store is considered a
-potential handle.  The type of the attribute is irrelevant; if the bytes happen
-to equal a known handle we assume a reference exists.  With 32‑byte hashes the
-chance of a random collision is vanishingly small, so a match strongly implies a
-real reference.  This heuristic may keep more blobs than strictly necessary but
-never frees ones that are still in use.
+Every commit and branch metadata record is stored as a `SimpleArchive`. The
+archive encodes a canonical `TribleSet` as alternating 32‑byte keys and values.
+Instead of deserialising the archive, the collector scans the raw bytes in
+32‑byte chunks. Each second chunk is treated as a candidate value. If a chunk
+matches the hash of a blob in the store we assume it is a reference, regardless
+of the attribute type. With 32‑byte hashes the odds of a random collision are
+negligible, so the scan may keep extra blobs but will not drop a referenced one.
 
 ## Traversal Algorithm
 
 1. Enumerate all branches and load their metadata blobs.
-2. For each metadata blob extract values that look like blob handles.  This
-   yields the current commit head as well as any other referenced blobs.
-3. Recursively walk commit and content blobs discovered this way.  Whenever a
+2. Extract candidate handles from the metadata. This reveals the current commit
+   head along with any other referenced blobs.
+3. Recursively walk the discovered commits and content blobs. Whenever a
    referenced blob is a `SimpleArchive`, scan every second 32‑byte segment for
-   handles instead of deserialising the entire set.
-4. Collect every handle visited during the walk into a `TribleSet`.  Repositories
-   that implement a `keep`‑style operation can feed this set back to the blob
-   store to drop everything else.
+   further handles instead of deserialising it.
+4. Collect all visited handles into a plain set or list of 32‑byte handles.
+   A `keep`‑style operation can pass this collection to the blob store and
+   prune everything else without imposing any trible semantics.
 
 Content blobs that are not `SimpleArchive` instances (for example large binary
-attachments) are treated as leaves.  They become reachable when some archive
-contains their handle and are otherwise eligible for forgetting.
+attachments) act as leaves. They become reachable when some archive references
+their handle and are otherwise eligible for forgetting.
 
 ## Future Work
 
-The exact API for triggering garbage collection is still open.  One option is a
-`Repository::forget_unreachable()` helper that relies on the blob store to
-implement a pruning method.  Another approach could expose a generic
-`ReachabilityWalker` so applications can decide how to handle or export reachable
-blobs.  Regardless of the final interface, conservative reachability based on
-scanning `SimpleArchive` bytes lays the groundwork for safe space reclamation.
+The public API for triggering garbage collection is still open. The blob store
+could expose a method that retains only a supplied collection of handles, or a
+helper such as `Repository::forget_unreachable()` might compute those handles
+before delegating pruning. A more flexible `ReachabilityWalker` could also let
+applications decide how to handle reachable blobs. Whatever interface emerges,
+conservative reachability by scanning `SimpleArchive` bytes lays the groundwork
+for safe space reclamation.


### PR DESCRIPTION
## Summary
- clarify traversal collects handles into a simple set and discuss API for retaining them
- note handle-based pruning in changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68969b799d808322a2269323fc154854