### PR TITLE
Add regression test for ordered patch iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation and example for incremental queries using `pattern_changes!`
   plus additional tests.
 - `pattern!` now implemented as a procedural macro in the new `tribles-macros` crate.
+- Regression test ensuring `PATCHOrderedIterator` returns keys in sorted order.
 - `entity!` now implemented as a procedural macro alongside `pattern!`.
 - `ThompsonEngine` implementing a new `PathEngine` trait for regular path queries,
   and `RegularPathConstraint` is now generic over `PathEngine`.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -82,6 +82,7 @@ prioritized for efficient zero-copy access.
 - Split out the lengthy explanation of trible structure from `src/trible.rs`
   and consolidate it with the deep dive chapter.
 - Add a FAQ chapter to the book summarising common questions.
+- Correct `PATCHOrderedIterator` doc comment; it currently references prefix iteration.
 
 ## Discovered Issues
 - No open issues recorded yet.

--- a/tests/patch_ordered_iterator.rs
+++ b/tests/patch_ordered_iterator.rs
@@ -1,0 +1,21 @@
+use rand::rngs::ThreadRng;
+use rand::RngCore;
+use tribles::patch::IdentityOrder;
+use tribles::patch::{Entry, PATCH};
+
+#[test]
+fn iter_ordered_returns_sorted_keys() {
+    const N: usize = 128;
+    let mut rng = ThreadRng::default();
+    let mut patch: PATCH<64, IdentityOrder> = PATCH::new();
+    let mut keys: Vec<[u8; 64]> = Vec::with_capacity(N);
+    for _ in 0..N {
+        let mut key = [0u8; 64];
+        rng.fill_bytes(&mut key);
+        patch.insert(&Entry::new(&key));
+        keys.push(key);
+    }
+    keys.sort();
+    let iter_keys: Vec<[u8; 64]> = patch.iter_ordered().map(|k| *k).collect();
+    assert_eq!(keys, iter_keys);
+}


### PR DESCRIPTION
## Summary
- add regression test ensuring `PATCHOrderedIterator` yields sorted keys
- record documentation fix in inventory

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a211b8ff288322803b39747a4c2901