### PR TITLE
Fix pile offsets for blob writes and branch heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branch heads when crashes occur before pending blobs flush.
 - Applied branch head updates immediately and sized branch records using
   `size_of` to preserve compare-and-swap semantics without magic numbers.
+- Removed remaining 64-byte assumptions from blob writes by computing header
+  length and padding with `size_of::<BlobHeader>()`.
 - `ignore!` now hides variables correctly by subtracting them from inner constraints.
 - ByteTable resize benchmark now reports load factor for fully populated 256-slot tables.
 - `PatchIdConstraint` incorrectly used 32-byte values when confirming IDs, causing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `RegularPathConstraint` is now generic over `PathEngine`.
 - Implemented `size_hint`, `ExactSizeIterator`, and `FusedIterator` for `PATCHIterator` and `PATCHOrderedIterator`.
 - Regression test ensures `PATCH::iter_ordered` yields canonically ordered keys.
+- Regression tests verify blob bytes remain intact after branch updates and across flushes.
 - Debug helpers `EstimateOverrideConstraint` and `DebugConstraint` moved to a new
   `debug` module.
 - Debug-only `debug_branch_fill` method computes average PATCH branch fill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `nth_parent` commit selector and helper; parent-numbering is not planned.
 ### Fixed
+- Corrected blob offsets in `Pile` so retrieved blobs no longer include headers or
+  branch records.
+- Scheduled branch writes through the pile's write handle to avoid orphaned
+  branch heads when crashes occur before pending blobs flush.
+- Applied branch head updates immediately and sized branch records using
+  `size_of` to preserve compare-and-swap semantics without magic numbers.
 - `ignore!` now hides variables correctly by subtracting them from inner constraints.
 - ByteTable resize benchmark now reports load factor for fully populated 256-slot tables.
 - `PatchIdConstraint` incorrectly used 32-byte values when confirming IDs, causing

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -32,6 +32,7 @@
 - Provide a macro to declare key layouts that emits segmentation and
   ordering implementations for PATCH at compile time.
 - Expose segment iterators on PATCH using `KeyOrdering`'s segment permutation instead of raw key ranges.
+- Consolidate pile header size constants to avoid repeated magic numbers.
 
 ## Additional Built-in Schemas
 The existing collection of schemas covers the basics like strings, large


### PR DESCRIPTION
## Summary
- start new blob slices after the header and adjust applied length for branch updates
- schedule branch writes through the write handle to avoid orphaned heads on crash
- update branch bookkeeping immediately and size branch records without magic numbers
- check that inserting after a branch keeps the head record and that unflushed branch updates don't persist
- document offset and branch write fixes and note future work on header constants

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a21d5d171483228c6dcb5ba9ba43f8