### PR TITLE
Sync branch headers to disk after updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PatchIdConstraint` incorrectly used 32-byte values when confirming IDs, causing
   `local_ids` queries to return no results with overridden estimates.
 - Documentation proposal for exposing blob metadata through the `Pile` API.
+- Branch updates now sync branch headers to disk to avoid losing branch pointers after crashes.
 - `IndexEntry` now stores a timestamp for each blob. `PileReader::metadata`
   returns this timestamp along with the blob length.
 - Design notes for a conservative garbage collection mechanism that scans

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -699,6 +699,10 @@ where
                 "pile misaligned after branch write"
             );
             self.applied_length = end;
+            if let Err(e) = self.file.sync_data() {
+                self.file.unlock()?;
+                return Err(UpdateBranchError::IoError(e));
+            }
             self.file.unlock()?;
             Ok(PushResult::Success())
         };


### PR DESCRIPTION
## Summary
- ensure `Pile::update` fsyncs branch headers after writing to avoid losing branch pointers on crash
- document branch header syncing in CHANGELOG

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa38ad9130832284d0c9b188d5dfee