### PR TITLE
Add pile unit tests for deduplication and conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branch occupancy averages.
 - Trible key segmentation and ordering tables are now generated from a
   declarative segment layout, simplifying maintenance.
+- Additional unit tests covering pile deduplication, metadata, and branch
+  update conflicts.
 
 ### Changed
 - Replaced fs4 with Rust std file-locking APIs.


### PR DESCRIPTION
## Summary
- test that inserting duplicate blobs does not grow the pile
- verify branch updates detect conflicts and preserve existing head
- cover blob metadata length reporting

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa33a909c88322a284709fe77b5045