### PR TITLE
Add pile branch conflict and size limit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branch occupancy averages.
 - Trible key segmentation and ordering tables are now generated from a
   declarative segment layout, simplifying maintenance.
+- Additional pile unit tests exercising branch conflicts and size limits.
 
 ### Changed
 - Replaced fs4 with Rust std file-locking APIs.

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -37,6 +37,7 @@
   ordering implementations for PATCH at compile time.
 - Expose segment iterators on PATCH using `KeySchema`'s segment permutation instead of raw key ranges.
 - Consolidate pile header size constants to avoid repeated magic numbers.
+- Develop property-based tests for pile operations to explore edge cases automatically.
 
 ## Additional Built-in Schemas
 The existing collection of schemas covers the basics like strings, large

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -711,6 +711,7 @@ where
 mod tests {
     use super::*;
 
+    use crate::repo::PushResult;
     use rand::RngCore;
     use std::io::Write;
     use tempfile;
@@ -935,6 +936,47 @@ mod tests {
         let pile: Pile<MAX_PILE_SIZE> = Pile::open(&path).unwrap();
         assert_eq!(pile.head(branch_id).unwrap(), Some(handle.transmute()));
         assert!(std::fs::metadata(&path).unwrap().len() > 0);
+    }
+
+    #[test]
+    fn branch_update_conflict_returns_current_head() {
+        const MAX_PILE_SIZE: usize = 1 << 20;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pile.pile");
+
+        let mut pile: Pile<MAX_PILE_SIZE> = Pile::open(&path).unwrap();
+        let blob1: Blob<UnknownBlob> = Blob::new(Bytes::from_source(vec![1u8; 5]));
+        let handle1 = pile.put(blob1).unwrap();
+        let branch_id = Id::new([1u8; 16]).unwrap();
+        pile.update(branch_id, None, handle1.transmute()).unwrap();
+        pile.flush().unwrap();
+
+        let blob2: Blob<UnknownBlob> = Blob::new(Bytes::from_source(vec![2u8; 5]));
+        let handle2 = pile.put(blob2).unwrap();
+
+        let result = pile
+            .update(branch_id, Some(handle2.transmute()), handle2.transmute())
+            .unwrap();
+        match result {
+            PushResult::Conflict(current) => assert_eq!(current, Some(handle1.transmute())),
+            other => panic!("unexpected result: {other:?}"),
+        }
+        assert_eq!(pile.head(branch_id).unwrap(), Some(handle1.transmute()));
+    }
+
+    #[test]
+    fn try_open_errors_when_file_exceeds_limit() {
+        const MAX_PILE_SIZE: usize = 1 << 10;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pile.pile");
+
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len((MAX_PILE_SIZE + 1) as u64).unwrap();
+
+        match Pile::<MAX_PILE_SIZE>::try_open(&path) {
+            Err(ReadError::PileTooLarge) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add unit tests for Pile branch update conflicts and file size limits
- record test coverage in changelog and inventory

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa33a909c88322a284709fe77b5045