### PR TITLE
Add proptest-based multi-handle pile simulation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branch occupancy averages.
 - Trible key segmentation and ordering tables are now generated from a
   declarative segment layout, simplifying maintenance.
+- Deterministic proptest simulation tests cover multi-reader and writer pile
+  operation sequences via actor-scheduled operations.
+- Simulation now exercises branch updates, branch listing, and fetching
+  previously stored blobs and branch heads for comprehensive pile coverage.
 
 ### Changed
 - Replaced fs4 with Rust std file-locking APIs.

--- a/tests/pile_sim.rs
+++ b/tests/pile_sim.rs
@@ -1,0 +1,203 @@
+use anybytes::Bytes;
+use proptest::prelude::*;
+use std::collections::{HashMap, HashSet};
+use tempfile;
+use tribles::blob::schemas::UnknownBlob;
+use tribles::prelude::blobschemas::SimpleArchive;
+use tribles::prelude::valueschemas::Handle;
+use tribles::prelude::*;
+use tribles::repo::PushResult;
+use tribles::value::schemas::hash::Blake3;
+
+#[derive(Debug, Clone)]
+enum Op {
+    Put(Vec<u8>),
+    Flush,
+    Refresh,
+    Get(usize),
+    BranchUpdate { branch: usize, handle: usize },
+    BranchHead(usize),
+    BranchList,
+}
+
+#[derive(Debug, Clone)]
+enum ActorOp {
+    Run { actor: usize, op: Op },
+    Check,
+}
+
+#[derive(Debug, Clone)]
+struct Scenario {
+    actors: usize,
+    ops: Vec<ActorOp>,
+}
+
+fn actor_op_strategy(actors: usize, branches: usize) -> impl Strategy<Value = ActorOp> {
+    let data = prop::collection::vec(any::<u8>(), 0..32);
+    let idx = 0usize..20;
+    prop_oneof![
+        (0..actors, data.clone()).prop_map(|(actor, data)| ActorOp::Run {
+            actor,
+            op: Op::Put(data)
+        }),
+        (0..actors).prop_map(|actor| ActorOp::Run {
+            actor,
+            op: Op::Flush
+        }),
+        (0..actors).prop_map(|actor| ActorOp::Run {
+            actor,
+            op: Op::Refresh
+        }),
+        (0..actors, idx.clone()).prop_map(|(actor, i)| ActorOp::Run {
+            actor,
+            op: Op::Get(i)
+        }),
+        (0..actors, 0..branches, idx.clone()).prop_map(|(actor, branch, i)| ActorOp::Run {
+            actor,
+            op: Op::BranchUpdate { branch, handle: i }
+        }),
+        (0..actors, 0..branches).prop_map(|(actor, branch)| ActorOp::Run {
+            actor,
+            op: Op::BranchHead(branch)
+        }),
+        (0..actors).prop_map(|actor| ActorOp::Run {
+            actor,
+            op: Op::BranchList
+        }),
+        Just(ActorOp::Check),
+    ]
+}
+
+fn scenario_strategy(max_actors: usize) -> impl Strategy<Value = Scenario> {
+    (1..=max_actors, 1usize..=4).prop_flat_map(move |(actors, branches)| {
+        let op = actor_op_strategy(actors, branches);
+        prop::collection::vec(op, 1..20).prop_map(move |ops| Scenario { actors, ops })
+    })
+}
+
+fn branch_id(idx: usize) -> Id {
+    let mut raw = [0u8; 16];
+    raw[0] = (idx as u8).saturating_add(1);
+    Id::new(raw).unwrap()
+}
+
+proptest! {
+    #[test]
+    fn pile_operation_sequences_are_consistent(
+        scenario in scenario_strategy(4)
+    ) {
+        const MAX_PILE_SIZE: usize = 1 << 20;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sim.pile");
+        let mut piles: Vec<Pile<MAX_PILE_SIZE>> =
+            (0..scenario.actors).map(|_| Pile::open(&path).unwrap()).collect();
+        let mut expected: HashMap<Value<Handle<Blake3, UnknownBlob>>, Vec<u8>> = HashMap::new();
+        let mut handles: Vec<Value<Handle<Blake3, UnknownBlob>>> = Vec::new();
+        let mut branches: HashMap<Id, Value<Handle<Blake3, SimpleArchive>>> = HashMap::new();
+
+        for op in scenario.ops {
+            match op {
+                ActorOp::Run { actor, op } => match op {
+                    Op::Put(data) => {
+                        let blob: Blob<UnknownBlob> =
+                            Blob::new(Bytes::from_source(data.clone()));
+                        let handle = piles[actor].put(blob).unwrap();
+                        expected.insert(handle, data);
+                        handles.push(handle);
+                    }
+                    Op::Flush => {
+                        piles[actor].flush().unwrap();
+                    }
+                    Op::Refresh => {
+                        let _ = piles[actor].refresh();
+                    }
+                    Op::Get(i) => {
+                        if !handles.is_empty() {
+                            let handle = handles[i % handles.len()];
+                            piles[actor].refresh().unwrap();
+                            if let Ok(blob) = piles[actor]
+                                .reader()
+                                .unwrap()
+                                .get::<Blob<UnknownBlob>, _>(handle)
+                            {
+                                prop_assert_eq!(
+                                    blob.bytes.as_ref(),
+                                    expected.get(&handle).unwrap().as_slice()
+                                );
+                            }
+                        }
+                    }
+                    Op::BranchUpdate { branch, handle } => {
+                        if !handles.is_empty() {
+                            let id = branch_id(branch);
+                            let h = handles[handle % handles.len()].transmute();
+                            let old = branches.get(&id).copied();
+                            let res = piles[actor].update(id, old, h).unwrap();
+                            match res {
+                                PushResult::Success() => {
+                                    branches.insert(id, h);
+                                }
+                                PushResult::Conflict(c) => {
+                                    prop_assert_eq!(c, old);
+                                    branches.insert(id, h);
+                                }
+                            }
+                        }
+                    }
+                    Op::BranchHead(branch) => {
+                        let id = branch_id(branch);
+                        piles[actor].refresh().unwrap();
+                        let head = piles[actor].head(id).unwrap();
+                        prop_assert_eq!(head, branches.get(&id).copied());
+                    }
+                    Op::BranchList => {
+                        piles[actor].refresh().unwrap();
+                        let found: HashSet<Id> =
+                            piles[actor].branches().map(|r| r.unwrap()).collect();
+                        let expected_ids: HashSet<Id> = branches.keys().copied().collect();
+                        prop_assert_eq!(found, expected_ids);
+                    }
+                },
+                ActorOp::Check => {
+                    for pile in &mut piles {
+                        pile.refresh().unwrap();
+                    }
+                    for pile in &mut piles {
+                        let reader = pile.reader().unwrap();
+                        for (handle, data) in &expected {
+                            if let Ok(blob) = reader.get::<Blob<UnknownBlob>, _>(*handle) {
+                                prop_assert_eq!(blob.bytes.as_ref(), data.as_slice());
+                            }
+                        }
+                        let found: HashSet<Id> =
+                            pile.branches().map(|r| r.unwrap()).collect();
+                        let expected_ids: HashSet<Id> = branches.keys().copied().collect();
+                        prop_assert_eq!(found, expected_ids);
+                        for (id, head) in &branches {
+                            let h = pile.head(*id).unwrap();
+                            prop_assert_eq!(h, Some(*head));
+                        }
+                    }
+                }
+            }
+        }
+
+        for pile in &mut piles {
+            pile.flush().unwrap();
+            pile.refresh().unwrap();
+        }
+        let mut pile_final: Pile<MAX_PILE_SIZE> = Pile::open(&path).unwrap();
+        let reader = pile_final.reader().unwrap();
+        for (handle, data) in &expected {
+            let blob = reader.get::<Blob<UnknownBlob>, _>(*handle).unwrap();
+            assert_eq!(blob.bytes.as_ref(), data.as_slice());
+        }
+        let found: HashSet<Id> = pile_final.branches().map(|r| r.unwrap()).collect();
+        let expected_ids: HashSet<Id> = branches.keys().copied().collect();
+        assert_eq!(found, expected_ids);
+        for (id, head) in &branches {
+            let h = pile_final.head(*id).unwrap();
+            assert_eq!(h, Some(*head));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor property-based pile simulation to drive operations via actor-aware ops, enabling arbitrary numbers of readers and writers
- record actor-scheduled simulation coverage in the changelog
- simulation now exercises branch updates, branch listing, and fetching previously stored blobs and branch heads for comprehensive pile coverage

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa209255208322b43341b53d3429eb