### PR TITLE
Use get_or_init for blob validation in Pile refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `refresh`; blob data is verified lazily on read.
 - `refresh` replaces invalid blob entries with newer candidates and verifies
   unknown duplicates before deciding whether to keep or replace them.
+- `refresh` now uses `get_or_init` to compute blob validation state and
+  replace invalid duplicates.
 - `BlobStore::reader` now returns a `Result` so implementations can signal errors during reader creation.
 - Renamed pile read errors from `OpenError` to `ReadError` since they can surface during refresh.
 - PATCH exposes const helpers to derive segment maps and ordering


### PR DESCRIPTION
## Summary
- simplify blob validation during refresh using `get_or_init`
- document blob validation refactor in changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab64d2a6c8832285192604300445fb