### PR TITLE
Remove static pile size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   update conflicts.
 
 ### Changed
+- `Pile` no longer requires a compile-time size limit, grows its mmap on demand,
+  and `ReadError::PileTooLarge` was removed.
+- Initial pile mapping now uses a page-sized (×1024) base to avoid frequent remaps.
+- Mapping size now derives from the mmap length instead of an internal counter.
 - Replaced fs4 with Rust std file-locking APIs.
 - Declared Rust 1.89 as the minimum supported toolchain.
 - Dropped the inventory item about validating externally appended blobs during

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ macro_pub = "0.1.0"
 uuid = "1.15.1"
 reft-light = "0.3.1"
 tribles-macros = { path = "tribles-macros" }
+page_size = "0.6.0"
 
 #[dev-dependencies]
 im = "15.1.0"

--- a/README.md
+++ b/README.md
@@ -51,10 +51,8 @@ use std::path::Path;
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 
-const MAX_PILE_SIZE: usize = 1 << 20;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pile: Pile<MAX_PILE_SIZE> = Pile::open(Path::new("example.pile"))?;
+    let pile = Pile::open(Path::new("example.pile"))?;
     let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
     let mut ws = repo.branch("main")?;
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -730,7 +730,6 @@ use tempfile::TempDir;
 fn pile_benchmark(c: &mut Criterion) {
     const RECORD_LEN: usize = 1 << 20; // 1k
     const RECORD_COUNT: usize = 1 << 10; // 1M
-    const MAX_PILE_SIZE: usize = 1 << 35; // 100GB
 
     let mut group = c.benchmark_group("pile");
     group.sample_size(10);
@@ -752,7 +751,7 @@ fn pile_benchmark(c: &mut Criterion) {
             |data: Vec<Bytes>| {
                 let tmp_dir = tempfile::tempdir().unwrap();
                 let tmp_pile = tmp_dir.path().join("test.pile");
-                let mut pile: Pile<MAX_PILE_SIZE> = Pile::open(&tmp_pile).unwrap();
+                let mut pile = Pile::open(&tmp_pile).unwrap();
                 data.iter().for_each(|data| {
                     pile.put(UnknownBlob::blob_from(data.clone())).unwrap();
                 });
@@ -781,7 +780,7 @@ fn pile_benchmark(c: &mut Criterion) {
             |data: Vec<Bytes>| {
                 let tmp_dir = tempfile::tempdir().unwrap();
                 let tmp_pile = tmp_dir.path().join("test.pile");
-                let mut pile: Pile<MAX_PILE_SIZE> = Pile::open(&tmp_pile).unwrap();
+                let mut pile = Pile::open(&tmp_pile).unwrap();
                 data.iter().for_each(|data| {
                     pile.put(UnknownBlob::blob_from(data.clone())).unwrap();
                     pile.flush().unwrap();
@@ -798,7 +797,7 @@ fn pile_benchmark(c: &mut Criterion) {
                 let mut rng = rand::thread_rng();
                 let tmp_dir = tempfile::tempdir().unwrap();
                 let tmp_pile = tmp_dir.path().join("test.pile");
-                let mut pile: Pile<MAX_PILE_SIZE> = Pile::open(&tmp_pile).unwrap();
+                let mut pile = Pile::open(&tmp_pile).unwrap();
 
                 (0..RECORD_COUNT).for_each(|_| {
                     let mut record = vec![0u8; RECORD_LEN];
@@ -814,7 +813,7 @@ fn pile_benchmark(c: &mut Criterion) {
             },
             |tmp_dir: TempDir| {
                 let tmp_pile = tmp_dir.path().join("test.pile");
-                let _pile: Pile<MAX_PILE_SIZE> = Pile::open(&tmp_pile).unwrap();
+                let _pile = Pile::open(&tmp_pile).unwrap();
                 drop(tmp_dir)
             },
             BatchSize::PerIteration,

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -18,10 +18,8 @@ use std::path::Path;
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 
-const MAX_PILE_SIZE: usize = 1 << 20;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pile: Pile<MAX_PILE_SIZE> = Pile::open(Path::new("example.pile"))?;
+    let pile = Pile::open(Path::new("example.pile"))?;
     let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
     let mut ws = repo.branch("main")?;
 

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -170,8 +170,8 @@ fn merge_import_example(
     dst_branch_id: tribles::id::Id,
 ) -> anyhow::Result<()> {
     // 1) Open source (read) and destination (write) piles
-    let mut src: Pile<{ 1 << 44 }, Blake3> = Pile::open(src_path)?;
-    let mut dst: Pile<{ 1 << 44 }, Blake3> = Pile::open(dst_path)?;
+    let mut src = Pile::open(src_path)?;
+    let mut dst = Pile::open(dst_path)?;
 
     // 2) Resolve source head commit handle
     let src_head: Value<Handle<Blake3, blobschemas::SimpleArchive>> =

--- a/examples/repo.rs
+++ b/examples/repo.rs
@@ -5,12 +5,11 @@ use tribles::prelude::*;
 use tribles::repo::Repository;
 
 fn main() {
-    const MAX_PILE_SIZE: usize = 1 << 20;
     let tmp = tempfile::tempdir().expect("tmp dir");
     let path = tmp.path().join("repo.pile");
 
     // Create a local pile to store blobs and branches
-    let pile: Pile<MAX_PILE_SIZE> = Pile::open(&path).expect("open pile");
+    let pile = Pile::open(&path).expect("open pile");
 
     // Create a repository from the pile and initialize the main branch
     let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));

--- a/tests/pile_sim.rs
+++ b/tests/pile_sim.rs
@@ -86,10 +86,9 @@ proptest! {
     fn pile_operation_sequences_are_consistent(
         scenario in scenario_strategy(4)
     ) {
-        const MAX_PILE_SIZE: usize = 1 << 20;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sim.pile");
-        let mut piles: Vec<Pile<MAX_PILE_SIZE>> =
+        let mut piles: Vec<Pile> =
             (0..scenario.actors).map(|_| Pile::open(&path).unwrap()).collect();
         let mut expected: HashMap<Value<Handle<Blake3, UnknownBlob>>, Vec<u8>> = HashMap::new();
         let mut handles: Vec<Value<Handle<Blake3, UnknownBlob>>> = Vec::new();
@@ -186,7 +185,7 @@ proptest! {
             pile.flush().unwrap();
             pile.refresh().unwrap();
         }
-        let mut pile_final: Pile<MAX_PILE_SIZE> = Pile::open(&path).unwrap();
+        let mut pile_final: Pile = Pile::open(&path).unwrap();
         let reader = pile_final.reader().unwrap();
         for (handle, data) in &expected {
             let blob = reader.get::<Blob<UnknownBlob>, _>(*handle).unwrap();


### PR DESCRIPTION
## Summary
- make `Pile` dynamically track and grow its mapped file size
- base the initial mapping on the system page size to reduce early remaps
- derive mapping size from the mmap's length instead of tracking a counter
- drop `ReadError::PileTooLarge` and handle mmap remapping failures with `io::Error`
- update examples, docs, benches and tests for non-generic `Pile`

## Testing
- `./scripts/devtest.sh`
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a289df88322ae1f860789ad1006