### PR TITLE
Simplify blob length handling in refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,10 +176,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and clearer `pattern_changes!` guidance.
 - Refined the book's introduction with a clearer overview of Trible Space and
   its flexible, lightweight query engine, plus links to later chapters.
+- Simplified blob length handling in `Pile::refresh` by relying on
+  `take_prefix`'s implicit bounds checking.
 ### Removed
 - `nth_parent` commit selector and helper; parent-numbering is not planned.
 - Unused `crossbeam-channel` dependency.
 ### Fixed
+- Detect oversized blob headers whose declared length exceeds the file size.
 - Restored atomic vectored blob appends and single-call branch writes; errors
   if any bytes are missing.
 - Removed duplicate `succinct-archive` feature declarations that prevented


### PR DESCRIPTION
## Summary
- rely on `Bytes::take_prefix` to detect blob headers that run past EOF and document the implicit corruption check
- note simplified blob validation in changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aca0a738888322b90472786f20fb32