### PR TITLE
Restrict compilation to 64-bit little-endian targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ThompsonEngine` implementing a new `PathEngine` trait for regular path queries,
   and `RegularPathConstraint` is now generic over `PathEngine`.
 - Implemented `size_hint`, `ExactSizeIterator`, and `FusedIterator` for `PATCHIterator` and `PATCHOrderedIterator`.
+- Compile-time check restricting builds to 64-bit little-endian targets.
 ### Changed
 - `PileReader` now reconstructs blob data from the underlying memory map,
   and `IndexEntry::Stored` tracks offsets and lengths instead of holding `Bytes` directly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 
 extern crate self as tribles;
 
+#[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+compile_error!("tribles-rust requires a 64-bit little-endian target");
+
 pub mod blob;
 pub mod id;
 pub mod metadata;


### PR DESCRIPTION
## Summary
- enforce 64-bit little-endian architecture at compile time

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68acec37ef948322b3f3746569c90fd8