### PR TITLE
Return time errors for Pile timestamp creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Enforce `PREFIX_LEN <= KEY_LEN` for prefix checks in PATCH.
 - Release file locks if `refresh` fails during pile branch updates to avoid lingering locks.
+- Blob insertion now returns an error instead of panicking if the system clock goes backwards.
 
 ## [0.5.2] - 2025-06-30
 ### Added


### PR DESCRIPTION
## Summary
- handle `SystemTime` regressions when inserting blobs by returning an error instead of panicking
- document the new timestamp error handling in the changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68acecba2b0c83228d223a3762996ef9