### PR TITLE
Ensure pile flush persists metadata with sync_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression test ensures `PATCH::iter_ordered` yields canonically ordered keys.
 - `PATCH::replace` method replaces existing keys without removing/ reinserting.
 - Regression tests verify blob bytes remain intact after branch updates and across flushes.
+- `Pile::flush` now calls `sync_all` to persist file metadata and prevent
+  potential data loss after crashes.
 - Debug helpers `EstimateOverrideConstraint` and `DebugConstraint` moved to a new
   `debug` module.
 - Debug-only `debug_branch_fill` method computes average PATCH branch fill

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -570,9 +570,9 @@ impl<H: HashProtocol> Pile<H> {
         Ok(())
     }
 
-    /// Persists all writes to the underlying pile file.
+    /// Persists all writes and metadata to the underlying pile file.
     pub fn flush(&mut self) -> Result<(), FlushError> {
-        self.file.sync_data()?;
+        self.file.sync_all()?;
         Ok(())
     }
 }
@@ -776,7 +776,7 @@ where
                 "pile misaligned after branch write"
             );
             self.applied_length = end;
-            if let Err(e) = self.file.sync_data() {
+            if let Err(e) = self.file.sync_all() {
                 self.file.unlock()?;
                 return Err(UpdateBranchError::IoError(e));
             }
@@ -1269,7 +1269,7 @@ mod tests {
                 .open(&path)
                 .unwrap();
             file.write_all(b"garbage").unwrap();
-            file.sync_data().unwrap();
+            file.sync_all().unwrap();
         }
 
         assert!(pile.refresh().is_err());
@@ -1302,7 +1302,7 @@ mod tests {
         let mut file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
         file.seek(SeekFrom::Start(header_len as u64)).unwrap();
         file.write_all(&[9u8; 4]).unwrap();
-        file.sync_data().unwrap();
+        file.sync_all().unwrap();
 
         // Append a valid copy using the second pile which hasn't seen the first one.
         let blob_dup: Blob<UnknownBlob> = Blob::new(Bytes::from_source(data.clone()));


### PR DESCRIPTION
## Summary
- ensure pile flush uses `sync_all` to persist file metadata
- replace remaining `sync_data` calls in pile and tests
- document durability fix in CHANGELOG

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ad7e88ac3883228c12dbb879055364