### PR TITLE
Verify blob hashes during pile iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression test ensures `PATCH::iter_ordered` yields canonically ordered keys.
 - `PATCH::replace` method replaces existing keys without removing/ reinserting.
 - Regression tests verify blob bytes remain intact after branch updates and across flushes.
+- `PileBlobStoreIter` now lazily verifies blob hashes and reports errors for invalid blobs.
 - `Pile::flush` now calls `sync_all` to persist file metadata and prevent
   potential data loss after crashes.
 - `Pile` requires explicit closure via `close()`; dropping without closing emits a warning.

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -617,12 +617,16 @@ pub struct PileBlobStoreIter<'a, H: HashProtocol> {
 }
 
 impl<'a, H: HashProtocol> Iterator for PileBlobStoreIter<'a, H> {
-    type Item = (Value<Handle<H, UnknownBlob>>, Blob<UnknownBlob>);
+    type Item =
+        Result<(Value<Handle<H, UnknownBlob>>, Blob<UnknownBlob>), GetBlobError<Infallible>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(key) = self.inner.next() {
             let entry = self.patch.get(key)?;
-            if let IndexEntry::Stored { offset, len, .. } = entry {
+            if let IndexEntry::Stored {
+                state, offset, len, ..
+            } = entry
+            {
                 let bytes = unsafe {
                     let slice =
                         slice_from_raw_parts(self.mmap.as_ptr().add(*offset), *len as usize)
@@ -631,7 +635,22 @@ impl<'a, H: HashProtocol> Iterator for PileBlobStoreIter<'a, H> {
                     Bytes::from_raw_parts(slice, self.mmap.clone())
                 };
                 let hash: Value<Hash<H>> = Value::new(*key);
-                return Some((hash.into(), Blob::new(bytes)));
+                let status = state.get_or_init(|| {
+                    let computed_hash = Hash::<H>::digest(&bytes);
+                    if computed_hash == hash {
+                        ValidationState::Validated
+                    } else {
+                        ValidationState::Invalid
+                    }
+                });
+                match status {
+                    ValidationState::Validated => {
+                        return Some(Ok((hash.into(), Blob::new(bytes))));
+                    }
+                    ValidationState::Invalid => {
+                        return Some(Err(GetBlobError::ValidationError(bytes)));
+                    }
+                }
             }
         }
         None
@@ -644,16 +663,18 @@ pub struct PileBlobStoreListIter<'a, H: HashProtocol> {
 }
 
 impl<'a, H: HashProtocol> Iterator for PileBlobStoreListIter<'a, H> {
-    type Item = Result<Value<Handle<H, UnknownBlob>>, Infallible>;
+    type Item = Result<Value<Handle<H, UnknownBlob>>, GetBlobError<Infallible>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (handle, _) = self.inner.next()?;
-        Some(Ok(handle))
+        match self.inner.next()? {
+            Ok((handle, _)) => Some(Ok(handle)),
+            Err(e) => Some(Err(e)),
+        }
     }
 }
 
 impl<H: HashProtocol> BlobStoreList<H> for PileReader<H> {
-    type Err = Infallible;
+    type Err = GetBlobError<Infallible>;
     type Iter<'a> = PileBlobStoreListIter<'a, H>;
 
     fn blobs(&self) -> Self::Iter<'_> {
@@ -1037,7 +1058,8 @@ mod tests {
         pile.flush().unwrap();
 
         let reader = pile.reader().unwrap();
-        for (handle, blob) in reader.iter() {
+        for item in reader.iter() {
+            let (handle, blob) = item.expect("infallible iteration");
             let data = expected.remove(&handle).unwrap();
             assert_eq!(blob.bytes.as_ref(), data.as_slice());
         }
@@ -1243,7 +1265,10 @@ mod tests {
         pile.flush().unwrap();
 
         let reader = pile.reader().unwrap();
-        let handles: Vec<_> = reader.iter().map(|(h, _)| h).collect();
+        let handles: Vec<_> = reader
+            .iter()
+            .map(|res| res.expect("infallible iteration").0)
+            .collect();
         assert!(handles.contains(&h1));
         assert!(handles.contains(&h2));
         assert_eq!(handles.len(), 2);

--- a/tests/pile_iter_validation.rs
+++ b/tests/pile_iter_validation.rs
@@ -1,0 +1,43 @@
+use std::fs::OpenOptions;
+use std::io::{Seek, SeekFrom, Write};
+
+use tribles::blob::schemas::UnknownBlob;
+use tribles::blob::{Blob, Bytes};
+use tribles::repo::pile::{GetBlobError, Pile};
+use tribles::repo::{BlobStore, BlobStorePut};
+
+// size of the blob header in the pile format
+const BLOB_HEADER_LEN: u64 = 16 + 8 + 8 + 32;
+
+#[test]
+fn iterator_errors_on_corrupt_blob() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pile.pile");
+
+    {
+        let mut pile: Pile = Pile::open(&path).unwrap();
+        let blob: Blob<UnknownBlob> = Blob::new(Bytes::from_source(b"hello world".as_slice()));
+        pile.put(blob).unwrap();
+        pile.flush().unwrap();
+        pile.close().unwrap();
+    }
+
+    // Corrupt the blob payload
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&path)
+        .unwrap();
+    file.seek(SeekFrom::Start(BLOB_HEADER_LEN)).unwrap();
+    file.write_all(&[0]).unwrap();
+    file.flush().unwrap();
+
+    let mut pile: Pile = Pile::open(&path).unwrap();
+    let reader = pile.reader().unwrap();
+    let mut iter = reader.iter();
+    match iter.next() {
+        Some(Err(GetBlobError::ValidationError(_))) => {}
+        other => panic!("expected validation error, got {:?}", other),
+    }
+    pile.close().unwrap();
+}


### PR DESCRIPTION
## Summary
- validate blob hashes lazily when iterating over a pile and propagate errors
- test that corrupted pile blobs are reported by the iterator

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68adadf1b494832295dcc9081bf3959e