### PR TITLE
Use padding_for_blob in refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unknown duplicates before deciding whether to keep or replace them.
 - `refresh` now uses `get_or_init` to compute blob validation state and
   replace invalid duplicates.
+- Simplified `refresh` padding logic by using `padding_for_blob` to compute blob alignment.
 - `BlobStore::reader` now returns a `Result` so implementations can signal errors during reader creation.
 - Renamed pile read errors from `OpenError` to `ReadError` since they can surface during refresh.
 - PATCH exposes const helpers to derive segment maps and ordering

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -496,7 +496,7 @@ impl<H: HashProtocol> Pile<H> {
                             }
                         })?;
                         let data_len = header.length as usize;
-                        let pad = (BLOB_ALIGNMENT - (data_len % BLOB_ALIGNMENT)) % BLOB_ALIGNMENT;
+                        let pad = padding_for_blob(data_len);
                         let data_offset = start_offset + BLOB_HEADER_LEN;
                         // `take_prefix` returns `None` if the slice is shorter than requested,
                         // implicitly guarding against blob headers that point past EOF.


### PR DESCRIPTION
## Summary
- use `padding_for_blob` in `Pile::refresh`
- update changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68adafdb079c83229ec19d0d19231ab3