### PR TITLE
Require explicit flush for durable branch updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `Pile::close` now consumes the pile and manually drops its fields to bypass
     `Drop`, which always warns when a pile is not explicitly closed.
+- `Pile::update` no longer flushes or `sync_all`s automatically; callers must
+    invoke `flush()` for durability.
 - Additional unit tests for `Pile` blob iteration, metadata, and conflict handling.
 - `Workspace::checkout` helper to load commit contents.
 - Documentation and example for incremental queries using `pattern_changes!`

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -775,15 +775,17 @@ where
         Ok(self.branches.get(&id).copied())
     }
 
+    /// Updates the head of `id` to `new` if it matches `old`.
+    ///
+    /// The update is written to the pile but is **not durable** until
+    /// [`Pile::flush`] is called. Callers must explicitly flush to ensure
+    /// branch updates survive crashes.
     fn update(
         &mut self,
         id: Id,
         old: Option<Value<Handle<H, SimpleArchive>>>,
         new: Value<Handle<H, SimpleArchive>>,
     ) -> Result<super::PushResult<H>, Self::UpdateError> {
-        self.flush().map_err(|e| match e {
-            FlushError::IoError(err) => UpdateBranchError::IoError(err),
-        })?;
         self.refresh().map_err(UpdateBranchError::from)?;
 
         self.file.lock()?;
@@ -825,10 +827,6 @@ where
                 "pile misaligned after branch write"
             );
             self.applied_length = end;
-            if let Err(e) = self.file.sync_all() {
-                self.file.unlock()?;
-                return Err(UpdateBranchError::IoError(e));
-            }
             self.branches.insert(id, new);
             self.file.unlock()?;
             Ok(PushResult::Success())
@@ -1169,7 +1167,7 @@ mod tests {
     }
 
     #[test]
-    fn branch_update_without_flush_keeps_head() {
+    fn branch_update_survives_manual_flush() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("pile.pile");
 
@@ -1180,6 +1178,7 @@ mod tests {
             let blob: Blob<UnknownBlob> = Blob::new(Bytes::from_source(vec![3u8; 5]));
             let handle = pile.put(blob).unwrap();
             pile.update(branch_id, None, handle.transmute()).unwrap();
+            pile.flush().unwrap();
             std::mem::forget(pile);
             handle
         };


### PR DESCRIPTION
## Summary
- stop `Pile::update` from implicitly flushing or fsyncing
- document need to call `flush` for branch durability
- add test covering branch persistence after manual flush
- note change in `CHANGELOG`

## Testing
- `./scripts/preflight.sh`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68adbe7e435c832298ab23acae74c7eb