### PR TITLE
Abort on pile truncation in Pile::refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `Pile::close` now consumes the pile and manually drops its fields to bypass
     `Drop`, which always warns when a pile is not explicitly closed.
+- `Pile::refresh` now aborts if the pile file shrinks, guarding against
+  truncated data.
 - Additional unit tests for `Pile` blob iteration, metadata, and conflict handling.
 - `Workspace::checkout` helper to load commit contents.
 - Documentation and example for incremental queries using `pattern_changes!`


### PR DESCRIPTION
## Summary
- abort if `Pile::refresh` sees the pile file shrink to prevent reading truncated data
- document abort-on-truncation behavior
- record new safety check in the changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68adbf6dbc1c8322836af1a3422fcc80