### PR TITLE
Refresh pile after branch updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   truncated data.
 - `Pile::update` no longer flushes or `sync_all`s automatically; callers must
     invoke `flush()` for durability.
+- `Pile::update` unlocks and refreshes before returning, so the branch state may
+  advance beyond the supplied head and corruption errors do not necessarily mean
+  the update failed.
 - Additional unit tests for `Pile` blob iteration, metadata, and conflict handling.
 - `Workspace::checkout` helper to load commit contents.
 - Documentation and example for incremental queries using `pattern_changes!`

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -76,6 +76,11 @@ while let Some(mut incoming) = repo.push(&mut ws)? {
 }
 ```
 
+After a successful push the branch may have advanced further than the head
+supplied, because the repository refreshes its view after releasing the lock.
+An error indicating a corrupted pile does not necessarily mean the push failed;
+the update might have been written before the corruption occurred.
+
 This snippet is taken from [`examples/workspace.rs`](../examples/workspace.rs).
 The [`examples/repo.rs`](../examples/repo.rs) example demonstrates the same
 pattern with two separate workspaces. The returned `Workspace` already contains


### PR DESCRIPTION
## Summary
- Refresh the pile after writing branch headers instead of mutating internal state.
- Clarify that pushes may observe newer branch state and corruption errors may occur after a successful update.
- Document the behavior change in the book and changelog.
- Remove redundant misalignment check after branch writes.
- Unlock the file before verifying header write result.

## Testing
- `cargo fmt`
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68adf4557ab88322818b67e67899c7fc