### PR TITLE
Make Pile::open lazy and remove try_open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Constraint::influence` method for identifying dependent variables.
 - Documentation and examples for the repository API.
 - Test coverage for `branch_from` and `pull_with_key`.
+- `Pile::restore` method to repair piles with trailing corruption.
 
 ### Changed
 - `Pile::close` now consumes the pile and manually drops its fields to bypass
@@ -29,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Pile::update` unlocks and refreshes before returning, so the branch state may
   advance beyond the supplied head and corruption errors do not necessarily mean
   the update failed.
+- `Pile::open` now returns an empty handle without scanning the file. Call
+  `refresh` to load existing data or `restore` to repair corruption. The
+  `try_open` helper was removed.
 - Additional unit tests for `Pile` blob iteration, metadata, and conflict handling.
 - `Workspace::checkout` helper to load commit contents.
 - Documentation and example for incremental queries using `pattern_changes!`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pile = Pile::open(Path::new("example.pile"))?;
+    let mut pile = Pile::open(Path::new("example.pile"))?;
+    pile.restore()?;
     let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
     let mut ws = repo.branch("main")?;
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -813,7 +813,8 @@ fn pile_benchmark(c: &mut Criterion) {
             },
             |tmp_dir: TempDir| {
                 let tmp_pile = tmp_dir.path().join("test.pile");
-                let _pile = Pile::open(&tmp_pile).unwrap();
+                let mut pile = Pile::open(&tmp_pile).unwrap();
+                pile.restore().unwrap();
                 drop(tmp_dir)
             },
             BatchSize::PerIteration,

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -19,7 +19,8 @@ use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let pile = Pile::open(Path::new("example.pile"))?;
+    let mut pile = Pile::open(Path::new("example.pile"))?;
+    pile.restore()?;
     let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
     let mut ws = repo.branch("main")?;
 

--- a/book/src/pile-metadata-proposal.md
+++ b/book/src/pile-metadata-proposal.md
@@ -11,7 +11,7 @@ file.
   can be determined from the stored bytes when needed.
 - Introduce a public `BlobMetadata` struct containing `timestamp` and `length`
   so callers do not depend on internal types.
-- Populate the timestamp when `Pile::try_open` scans existing entries and when
+- Populate the timestamp when `Pile::refresh` scans existing entries and when
   inserting new blobs. Lengths are computed on demand.
 - Add `PileReader::metadata(&self, handle)` to retrieve a blob's metadata if it
   exists. Iterators may later be extended to yield this information alongside the

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -176,7 +176,9 @@ fn merge_import_example(
 ) -> anyhow::Result<()> {
     // 1) Open source (read) and destination (write) piles
     let mut src = Pile::open(src_path)?;
+    src.restore()?;
     let mut dst = Pile::open(dst_path)?;
+    dst.restore()?;
 
     // 2) Resolve source head commit handle
     let src_head: Value<Handle<Blake3, blobschemas::SimpleArchive>> =

--- a/examples/repo.rs
+++ b/examples/repo.rs
@@ -9,7 +9,8 @@ fn main() {
     let path = tmp.path().join("repo.pile");
 
     // Create a local pile to store blobs and branches
-    let pile = Pile::open(&path).expect("open pile");
+    let mut pile = Pile::open(&path).expect("open pile");
+    pile.restore().expect("restore pile");
 
     // Create a repository from the pile and initialize the main branch
     let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));

--- a/tests/pile_iter_validation.rs
+++ b/tests/pile_iter_validation.rs
@@ -33,6 +33,7 @@ fn iterator_errors_on_corrupt_blob() {
     file.flush().unwrap();
 
     let mut pile: Pile = Pile::open(&path).unwrap();
+    pile.restore().unwrap();
     let reader = pile.reader().unwrap();
     let mut iter = reader.iter();
     match iter.next() {

--- a/tests/pile_metadata.rs
+++ b/tests/pile_metadata.rs
@@ -38,6 +38,7 @@ fn metadata_detects_corrupted_blob() {
     }
 
     let mut reopened: Pile<Blake3> = Pile::open(&path).unwrap();
+    reopened.restore().unwrap();
     let reader = reopened.reader().unwrap();
     assert!(reader.metadata(handle).is_none());
 }

--- a/tests/pile_sim.rs
+++ b/tests/pile_sim.rs
@@ -189,6 +189,7 @@ proptest! {
             pile.close().unwrap();
         }
         let mut pile_final: Pile = Pile::open(&path).unwrap();
+        pile_final.restore().unwrap();
         let reader = pile_final.reader().unwrap();
         for (handle, data) in &expected {
             let blob = reader.get::<Blob<UnknownBlob>, _>(*handle).unwrap();


### PR DESCRIPTION
## Summary
- make `Pile::open` return an empty handle that requires `refresh` or `restore` to load data
- drop `Pile::try_open` and update tests, docs, and examples accordingly
- document the new opening semantics

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aef21de4d4832292e622d7e1cee549