### PR TITLE
Document pile writer filesystem requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Pile::restore` method to repair piles with trailing corruption.
 
 ### Changed
+- Clarified that multiple pile writers require filesystems with atomic append
+  semantics; noted unsupported filesystems in documentation.
 - Documented the pile as a write-ahead log database ("WAL-as-a-DB").
 - Removed in-flight blob tracking. `Pile::put` now holds a shared lock,
   refreshes before writing, then reads back its blob with `apply_next` to ensure

--- a/book/src/pile-format.md
+++ b/book/src/pile-format.md
@@ -41,6 +41,10 @@ requires a brief critical
 section: `flush → refresh → lock → refresh → append → unlock`. The initial
 `refresh` acquires a shared lock so it cannot race with `restore`, which takes an
 exclusive lock before truncating a corrupted tail.
+ 
+Filesystems lacking atomic `write`/`vwrite` appends—such as some network or
+FUSE-based implementations—cannot safely host multiple writers and are not
+supported. Using such filesystems risks pile corruption.
 ## Blob Storage
 ```
                              8 byte  8 byte

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -723,6 +723,10 @@ impl<H: HashProtocol> BlobStoreList<H> for PileReader<H> {
 impl<H: HashProtocol> BlobStorePut<H> for Pile<H> {
     type PutError = InsertError;
 
+    /// Inserts a blob into the pile and returns its handle.
+    ///
+    /// Multiple writers are safe only on filesystems guaranteeing atomic
+    /// `write`/`vwrite` appends; other filesystems may corrupt the pile.
     fn put<S, T>(&mut self, item: T) -> Result<Value<Handle<H, S>>, Self::PutError>
     where
         S: BlobSchema + 'static,


### PR DESCRIPTION
## Summary
- document that concurrent writers require atomic `write`/`vwrite` appends
- note unsupported filesystems in pile format documentation
- record filesystem requirement docs in changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b0b8f9ff888322b2944feda041a32c