### PR TITLE
Document abort on pile truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   using `apply_next` under its exclusive lock.
 - `Pile::close` now consumes the pile and manually drops its fields to bypass
     `Drop`, which always warns when a pile is not explicitly closed.
-- `Pile::refresh` now aborts if the pile file shrinks, guarding against
-  truncated data.
+- `Pile::refresh` now aborts if the pile file shrinks below data already
+  applied, guarding against truncated data.
 - Documented that truncation below `applied_length` invalidates previously
   issued `Bytes`, so only the un-applied tail is checked for corruption and
-  shrinkage requires aborting.
+  shrinkage into validated data requires aborting.
+- Clarified that shrinkage into already applied data triggers an immediate
+  process abort to avoid undefined behavior from dangling `Bytes` handles.
 - `Pile::refresh` acquires a shared file lock while scanning to avoid races with
   `restore` truncating the file.
 - `Pile::restore` truncates the pile without rescanning after truncation,

--- a/book/src/pile-format.md
+++ b/book/src/pile-format.md
@@ -74,6 +74,11 @@ verify any hashes. If a truncated or unknown block is found the function reports
 the number of bytes that were valid so far using
 [`ReadError::CorruptPile`].
 
+If the file shrinks between scans into data that has already been applied, the
+process aborts immediately. Previously returned `Bytes` handles would dangle and
+continuing could cause undefined behavior, so truncation into validated data is
+treated as unrecoverable.
+
 `refresh` holds a shared file lock while scanning. This prevents a concurrent
 [`restore`](../../src/repo/pile.rs) call from truncating the file out from under
 the reader.


### PR DESCRIPTION
## Summary
- document that truncation into already applied data causes an immediate abort to avoid dangling `Bytes`
- clarify this failure mode in the book’s recovery section

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0b9088b7083229b6f4d7c4dc4f101