### PR TITLE
Document immutability assumptions for pile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Documented the pile as a write-ahead log database ("WAL-as-a-DB").
+- Documented that the pile is an immutable append-only log: only the un-applied tail is validated and mutating existing data is undefined behavior.
 - Removed in-flight blob tracking. `Pile::put` now holds a shared lock,
   refreshes before writing, then reads back its blob with `apply_next` to ensure
   it was indexed. `Pile::update` similarly verifies the written branch record

--- a/book/src/pile-format.md
+++ b/book/src/pile-format.md
@@ -17,6 +17,16 @@ alignment ensures each entry begins on a cache line boundary, which improves
 concurrent access patterns and allows safe typed views with the `zerocopy`
 crate.
 
+## Immutability Assumptions
+
+A pile is treated as an immutable append-only log. Once a record sits below a
+process's applied offset, its bytes are assumed permanent. The implementation
+does not guard against mutations; modifying existing bytes is undefined
+behavior. Only the tail beyond the applied offset might hide a partial append
+after a crash, so validation and repair only operate on that region. Each
+record's validation state is cached for the lifetime of the process under this
+assumption.
+
 Hash verification only happens when blobs are read. Opening even a very large
 pile is therefore fast while still catching corruption before data is used.
 

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -6,6 +6,15 @@
 //! All indices and metadata are reconstructed from the log on startup and no
 //! additional state is persisted elsewhere.
 //!
+//! The pile treats its file as an immutable append-only log. Once a record lies
+//! below `applied_length` and its bytes have been returned by
+//! [`get`](Pile::get) or [`apply_next`](Pile::apply_next), those bytes are
+//! assumed permanent. Modifying any part of the pile other than appending new
+//! records is undefined behaviour. The un-applied tail may hide a partial
+//! append after a crash, so validation and repair only operate on offsets
+//! beyond `applied_length`. Each record's [`ValidationState`] is cached for the
+//! lifetime of the process under this immutability assumption.
+//!
 //! For layout and recovery details see the [Pile
 //! Format](../../book/src/pile-format.md) chapter of the Tribles Book.
 


### PR DESCRIPTION
## Summary
- clarify pile docs to describe the file as an immutable append-only log where only the un-applied tail may change
- explain the append-only assumption in the pile format chapter
- record the immutability framing in the changelog

## Testing
- `cargo fmt`
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0b8e09d448322b74003eccf905ec6