### PR TITLE
Handle flush errors gracefully in Pile::close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   using `apply_next` under its exclusive lock.
 - `Pile::close` now consumes the pile and manually drops its fields to bypass
     `Drop`, which always warns when a pile is not explicitly closed.
+- `Pile::close` now drops all fields before returning the result of `flush`,
+  ensuring resources are cleaned up even if flushing fails.
 - `Pile::refresh` now aborts if the pile file shrinks below data already
   applied, guarding against truncated data.
 - Documented that truncation below `applied_length` invalidates previously

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -658,7 +658,7 @@ impl<H: HashProtocol> Pile<H> {
     /// Flushes pending data and consumes the pile, returning an error if the
     /// flush fails.
     pub fn close(mut self) -> Result<(), FlushError> {
-        self.flush()?;
+        let res = self.flush();
 
         let mut this = std::mem::ManuallyDrop::new(self);
         unsafe {
@@ -668,7 +668,7 @@ impl<H: HashProtocol> Pile<H> {
             std::ptr::drop_in_place(&mut this.branches);
         }
 
-        Ok(())
+        res
     }
 }
 


### PR DESCRIPTION
## Summary
- capture the result of `flush` in `Pile::close` and drop resources before returning it
- document improved `Pile::close` cleanup in the changelog

## Testing
- `cargo fmt -- src/repo/pile.rs`
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0ca11397c83228011fe56f37b8e38