### PR TITLE
Handle missing index entries during pile iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression tests verify blob bytes remain intact after branch updates and across flushes.
 - `PileReader::metadata` now validates blob contents and returns `None` for corrupted blobs.
 - `PileBlobStoreIter` now lazily verifies blob hashes and reports errors for invalid blobs.
+- `PileBlobStoreIter` now skips missing index entries instead of ending iteration silently.
 - `Pile::flush` now calls `sync_all` to persist file metadata and prevent
   potential data loss after crashes.
 - `Pile` requires explicit closure via `close()`; dropping without closing emits a warning.


### PR DESCRIPTION
## Summary
- reuse `PileReader::get` in `PileBlobStoreIter` to avoid duplicating blob validation logic
- update missing-index regression test to use the refactored iterator

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0c619f9548322a9547240da2b7210