### PR TITLE
Document zero-length blob support and test empty blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation and examples for the repository API.
 - Test coverage for `branch_from` and `pull_with_key`.
 - `Pile::restore` method to repair piles with trailing corruption.
+- Documented zero-length blob support and added tests for empty blob insertion and retrieval.
 
 ### Changed
 - Documented that branch updates do not ensure referenced blobs exist, enabling

--- a/book/src/pile-format.md
+++ b/book/src/pile-format.md
@@ -71,7 +71,7 @@ supported. Using such filesystems risks pile corruption.
           │ │                                                              │
           └ └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─┘
 ```
-Each blob entry records its creation timestamp, the length of the payload and
+Each blob entry records its creation timestamp, the length of the payload (which may be zero) and
 its hash. The payload is padded so the next record begins on a
 64&nbsp;byte boundary.
 

--- a/tests/pile_empty_blob.rs
+++ b/tests/pile_empty_blob.rs
@@ -1,0 +1,30 @@
+use anybytes::Bytes;
+use tempfile::tempdir;
+use tribles::blob::{schemas::UnknownBlob, Blob};
+use tribles::prelude::{BlobStore, BlobStoreGet, BlobStorePut};
+use tribles::repo::pile::Pile;
+use tribles::value::schemas::hash::Blake3;
+
+#[test]
+fn put_and_get_empty_blob() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("pile.pile");
+
+    let handle = {
+        let mut pile: Pile<Blake3> = Pile::open(&path).unwrap();
+        let blob: Blob<UnknownBlob> = Blob::new(Bytes::from_source(Vec::<u8>::new()));
+        let handle = pile.put(blob).unwrap();
+        pile.flush().unwrap();
+        pile.close().unwrap();
+        handle
+    };
+
+    let mut reopened: Pile<Blake3> = Pile::open(&path).unwrap();
+    let blob = reopened
+        .reader()
+        .unwrap()
+        .get::<Blob<UnknownBlob>, _>(handle)
+        .unwrap();
+    assert!(blob.bytes.as_ref().is_empty());
+    reopened.close().unwrap();
+}


### PR DESCRIPTION
## Summary
- document that the pile format allows zero-length blob payloads
- add test ensuring piles handle inserting and reading empty blobs
- note support for empty blobs in the changelog

## Testing
- `cargo fmt`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b0caa016fc8322a859fc399382abc3