### PR TITLE
Sync pile after truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PileBlobStoreIter` now skips missing index entries instead of ending iteration silently.
 - `Pile::flush` now calls `sync_all` to persist file metadata and prevent
   potential data loss after crashes.
+- `Pile::restore` now syncs the file after truncation to ensure durability.
 - `Pile` requires explicit closure via `close()`; dropping without closing emits a warning.
 - Debug helpers `EstimateOverrideConstraint` and `DebugConstraint` moved to a new
   `debug` module.

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -634,6 +634,7 @@ impl<H: HashProtocol> Pile<H> {
                     Ok(()) => Ok(()),
                     Err(ReadError::CorruptPile { valid_length }) => {
                         self.file.set_len(valid_length as u64)?;
+                        self.file.sync_all()?;
                         self.applied_length = valid_length;
                         Ok(())
                     }


### PR DESCRIPTION
## Summary
- ensure `Pile::restore` syncs the file after truncation
- document file syncing in changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b0d9eea10483228b281d3e3beb5469