### PR TITLE
Refresh pile branches before listing or fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented zero-length blob support and added tests for empty blob insertion and retrieval.
 
 ### Changed
+- `BranchStore::branches` now returns a `Result` and both branch operations
+  require mutable access. `Pile::branches` and `Pile::head` refresh
+  automatically and propagate `ReadError` to callers.
 - Documented that branch updates do not ensure referenced blobs exist, enabling
   piles to serve as head-only stores.
 - Clarified that multiple pile writers require filesystems with atomic append

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -252,7 +252,7 @@ pub trait BranchStore<H: HashProtocol> {
 
     /// Lists all branches in the repository.
     /// This function returns a stream of branch ids.
-    fn branches<'a>(&'a self) -> Self::ListIter<'a>;
+    fn branches<'a>(&'a mut self) -> Result<Self::ListIter<'a>, Self::BranchesError>;
 
     /// Retrieves a branch from the repository by its id.
     /// The id is a unique identifier for the branch, and is used to retrieve it from the repository.
@@ -266,7 +266,7 @@ pub trait BranchStore<H: HashProtocol> {
     /// # Returns
     /// * A future that resolves to the handle of the branch.
     /// * The handle is a unique identifier for the branch, and is used to retrieve it from the repository.
-    fn head(&self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError>;
+    fn head(&mut self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError>;
 
     /// Puts a branch on the repository, creating or updating it.
     ///
@@ -822,9 +822,12 @@ where
 
     /// Find the id of a branch by its name.
     pub fn branch_id_by_name(&mut self, name: &str) -> Result<Option<Id>, LookupError<Storage>> {
-        let ids: Vec<Id> = self
+        let ids_iter = self
             .storage
             .branches()
+            .map_err(|e| LookupError::StorageBranches(e))?;
+
+        let ids: Vec<Id> = ids_iter
             .map(|r| r.map_err(|e| LookupError::StorageBranches(e)))
             .collect::<Result<_, _>>()?;
 

--- a/src/repo/hybridstore.rs
+++ b/src/repo/hybridstore.rs
@@ -75,11 +75,11 @@ where
         R: 'a,
         B: 'a;
 
-    fn branches<'a>(&'a self) -> Self::ListIter<'a> {
+    fn branches<'a>(&'a mut self) -> Result<Self::ListIter<'a>, Self::BranchesError> {
         self.branches.branches()
     }
 
-    fn head(&self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError> {
+    fn head(&mut self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError> {
         self.branches.head(id)
     }
 

--- a/src/repo/memoryrepo.rs
+++ b/src/repo/memoryrepo.rs
@@ -51,17 +51,18 @@ impl BranchStore<Blake3> for MemoryRepo {
 
     type ListIter<'a> = std::vec::IntoIter<Result<Id, Self::BranchesError>>;
 
-    fn branches<'a>(&'a self) -> Self::ListIter<'a> {
-        self.branches
+    fn branches<'a>(&'a mut self) -> Result<Self::ListIter<'a>, Self::BranchesError> {
+        Ok(self
+            .branches
             .keys()
             .cloned()
             .map(Ok)
             .collect::<Vec<_>>()
-            .into_iter()
+            .into_iter())
     }
 
     fn head(
-        &self,
+        &mut self,
         id: Id,
     ) -> Result<Option<Value<Handle<Blake3, SimpleArchive>>>, Self::HeadError> {
         Ok(self.branches.get(&id).cloned())

--- a/src/repo/objectstore.rs
+++ b/src/repo/objectstore.rs
@@ -170,7 +170,7 @@ where
 
     type ListIter<'a> = BlockingIter<Result<Id, Self::BranchesError>>;
 
-    fn branches<'a>(&'a self) -> Self::ListIter<'a> {
+    fn branches<'a>(&'a mut self) -> Result<Self::ListIter<'a>, Self::BranchesError> {
         let prefix = self.prefix.child(BRANCH_INFIX);
         let stream = self.store.list(Some(&prefix)).map(|r| match r {
             Ok(meta) => {
@@ -186,10 +186,10 @@ where
             }
             Err(e) => Err(ListBranchesErr::List(e)),
         });
-        BlockingIter::new(stream)
+        Ok(BlockingIter::new(stream))
     }
 
-    fn head(&self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError> {
+    fn head(&mut self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError> {
         let path = self.prefix.child(BRANCH_INFIX).child(hex::encode(id));
         let result = block_on(async { self.store.get(&path).await });
         match result {

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -835,7 +835,7 @@ pub struct PileBranchStoreIter<'a, H: HashProtocol> {
 }
 
 impl<'a, H: HashProtocol> Iterator for PileBranchStoreIter<'a, H> {
-    type Item = Result<Id, std::convert::Infallible>;
+    type Item = Result<Id, ReadError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|id| Ok(*id))
@@ -846,19 +846,21 @@ impl<H> BranchStore<H> for Pile<H>
 where
     H: HashProtocol,
 {
-    type BranchesError = std::convert::Infallible;
-    type HeadError = std::convert::Infallible;
+    type BranchesError = ReadError;
+    type HeadError = ReadError;
     type UpdateError = UpdateBranchError;
 
     type ListIter<'a> = PileBranchStoreIter<'a, H>;
 
-    fn branches<'a>(&'a self) -> Self::ListIter<'a> {
-        PileBranchStoreIter {
+    fn branches<'a>(&'a mut self) -> Result<Self::ListIter<'a>, Self::BranchesError> {
+        self.refresh()?;
+        Ok(PileBranchStoreIter {
             iter: self.branches.keys(),
-        }
+        })
     }
 
-    fn head(&self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError> {
+    fn head(&mut self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError> {
+        self.refresh()?;
         Ok(self.branches.get(&id).copied())
     }
 
@@ -1415,6 +1417,29 @@ mod tests {
             other => panic!("unexpected result: {other:?}"),
         }
         assert_eq!(pile.head(branch_id).unwrap(), Some(h1.transmute()));
+        pile.close().unwrap();
+    }
+
+    #[test]
+    fn head_refreshes_without_explicit_refresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pile.pile");
+
+        {
+            let mut pile: Pile = Pile::open(&path).unwrap();
+            let branch_id = Id::new([1u8; 16]).unwrap();
+            let head = Value::<Handle<Blake3, SimpleArchive>>::new([2u8; 32]);
+            pile.update(branch_id, None, head).unwrap();
+            pile.flush().unwrap();
+            pile.close().unwrap();
+        }
+
+        let mut pile: Pile = Pile::open(&path).unwrap();
+        let branch_id = Id::new([1u8; 16]).unwrap();
+        assert_eq!(
+            pile.head(branch_id).unwrap(),
+            Some(Value::<Handle<Blake3, SimpleArchive>>::new([2u8; 32]))
+        );
         pile.close().unwrap();
     }
 

--- a/tests/pile_sim.rs
+++ b/tests/pile_sim.rs
@@ -152,7 +152,7 @@ proptest! {
                     Op::BranchList => {
                         piles[actor].refresh().unwrap();
                         let found: HashSet<Id> =
-                            piles[actor].branches().map(|r| r.unwrap()).collect();
+                            piles[actor].branches().unwrap().map(|r| r.unwrap()).collect();
                         let expected_ids: HashSet<Id> = branches.keys().copied().collect();
                         prop_assert_eq!(found, expected_ids);
                     }
@@ -169,7 +169,7 @@ proptest! {
                             }
                         }
                         let found: HashSet<Id> =
-                            pile.branches().map(|r| r.unwrap()).collect();
+                            pile.branches().unwrap().map(|r| r.unwrap()).collect();
                         let expected_ids: HashSet<Id> = branches.keys().copied().collect();
                         prop_assert_eq!(found, expected_ids);
                         for (id, head) in &branches {
@@ -195,7 +195,8 @@ proptest! {
             let blob = reader.get::<Blob<UnknownBlob>, _>(*handle).unwrap();
             assert_eq!(blob.bytes.as_ref(), data.as_slice());
         }
-        let found: HashSet<Id> = pile_final.branches().map(|r| r.unwrap()).collect();
+        let found: HashSet<Id> =
+            pile_final.branches().unwrap().map(|r| r.unwrap()).collect();
         let expected_ids: HashSet<Id> = branches.keys().copied().collect();
         assert_eq!(found, expected_ids);
         for (id, head) in &branches {


### PR DESCRIPTION
## Summary
- refresh pile branch indices before serving `branches` or `head`
- surface `ReadError` from branch accessors and update `BranchStore` to return `Result`
- test automatic refresh of branch heads when reopening a pile

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b19e59f8908322bd8dd26154a19f43