### PR TITLE
Update branch walkthroughs to use create_branch workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deduplicated value sequences.
 
 ### Changed
+- Updated the README and book examples to use `Repository::create_branch` plus
+  `pull` instead of the removed `branch` helper when initializing workspaces.
 - Updated `SuccinctArchive` to use `BitVectorDataMeta` for prefix bit vectors.
 - `SuccinctArchive` now derives domain metadata via `Serializable` instead of storing raw handles.
 - `SuccinctArchive` now retains a handle to a contiguous byte area so blob serialization clones the underlying bytes without rebuilding.

--- a/README.md
+++ b/README.md
@@ -56,13 +56,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut pile = Pile::open(Path::new("example.pile"))?;
     pile.restore()?;
     let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
-    let mut ws = repo.branch("main")?;
+    let branch_id = repo.create_branch("main", None)?;
+    let mut ws = repo.pull(*branch_id)?;
 
     ws.commit(crate::entity!{ &ufoid() @ literature::firstname: "Alice" }, None);
     repo.push(&mut ws)?;
     Ok(())
 }
 ```
+
+`Repository::create_branch` returns an `ExclusiveId` guard for the new branch.
+Dereference it (or call `release`) when passing the branch identifier to
+`Repository::pull` so additional workspaces can target the same branch.
 
 # Example
 

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -22,7 +22,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut pile = Pile::open(Path::new("example.pile"))?;
     pile.restore()?;
     let mut repo = Repository::new(pile, SigningKey::generate(&mut OsRng));
-    let mut ws = repo.branch("main")?;
+    let branch_id = repo.create_branch("main", None)?;
+    let mut ws = repo.pull(*branch_id)?;
 
     ws.commit(crate::entity!{ &ufoid() @ literature::firstname: "Alice" }, None);
     repo.push(&mut ws)?;
@@ -31,7 +32,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Running this program with `cargo run` creates an `example.pile` file in the current
-directory and pushes a single entity to the `main` branch.
+directory and pushes a single entity to the `main` branch. `Repository::create_branch`
+registers the branch and returns an `ExclusiveId` guard; pass its `Id`
+to `Repository::pull` (via dereferencing or `ExclusiveId::release`) to obtain a
+`Workspace` for writing commits.
 
 See the [crate documentation](https://docs.rs/tribles/latest/tribles/) for
 additional modules and examples.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -32,7 +32,8 @@
 //!
 //! let storage = MemoryRepo::default();
 //! let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
-//! let mut ws = repo.branch("main").expect("create branch");
+//! let branch_id = repo.create_branch("main", None).expect("create branch");
+//! let mut ws = repo.pull(*branch_id).expect("pull branch");
 //!
 //! attributes! {
 //!     "8F180883F9FD5F787E9E0AF0DF5866B9" as pub author: GenId;
@@ -54,6 +55,7 @@
 //! }
 //! ```
 //!
+//! `create_branch` registers a new branch and returns an `ExclusiveId` guard.
 //! `pull` creates a new workspace from an existing branch while
 //! `branch_from` can be used to start a new branch from a specific commit
 //! handle. See `examples/workspace.rs` for a more complete example.
@@ -83,8 +85,8 @@
 //! - A `Repository` stores commits and branch metadata similar to a remote.
 //! - `Workspace` is akin to a working directory combined with an index. It
 //!   tracks changes against a branch head until you `push` them.
-//! - `branch` and `branch_from` correspond to creating new branches from the
-//!   current head or from a specific commit, respectively.
+//! - `create_branch` and `branch_from` correspond to creating new branches from
+//!   scratch or from a specific commit, respectively.
 //! - `push` updates the repository atomically. If the branch advanced in the
 //!   meantime, you receive a conflict workspace which can be merged before
 //!   retrying the push.
@@ -92,7 +94,7 @@
 //!
 //! `pull` uses the repository's default signing key for new commits. If you
 //! need to work with a different identity, the `_with_key` variants allow providing
-//! an explicit key when branching or checking out.
+//! an explicit key when creating branches or pulling workspaces.
 //!
 //! These parallels should help readers leverage their Git knowledge when
 //! working with trible repositories.


### PR DESCRIPTION
## Summary
- update the README and book walkthroughs to create branches with `Repository::create_branch` and open workspaces with `pull`
- explain the `ExclusiveId` guard returned from `create_branch` and reflect the new flow in the repository module docs
- record the documentation refresh in the changelog

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68ced5153a948322a1637308af56ed4b