### PR TITLE
Clarify error handling when closing pile-backed repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unstable iterator detection.
 - Universes now allocate their own byte sections via a `SectionWriter`, so callers only pass an iterator. `CompressedUniverse::with` no longer clones its values.
 - `SuccinctArchive` constructs universes with `with_sorted_dedup`, avoiding an extra sort/dedup pass when the caller already guarantees ordering.
+- Getting started guide now highlights the need to close pile-backed repositories so callers can handle flush errors explicitly.
 - `with_sorted_dedup` now accepts iterators so compressed universes can build domains without materializing values.
 - `SuccinctArchiveMeta` now accepts the domain's serialized metadata type,
   removing its hardcoded `SectionHandle<RawValue>` dependency.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -26,12 +26,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     ws.commit(crate::entity!{ &ufoid() @ literature::firstname: "Alice" }, None);
     repo.push(&mut ws)?;
+    repo.close()?;
     Ok(())
 }
 ```
 
 Running this program with `cargo run` creates an `example.pile` file in the current
 directory and pushes a single entity to the `main` branch.
+
+When working with pile-backed repositories it is important to close them
+explicitly once you are done so buffered data is flushed and any errors are
+reported while you can still decide how to handle them. The `repo.close()?;`
+call in the example surfaces those errors; if the repository were only dropped,
+failures would have to be logged or panic instead. Alternatively, you can
+recover the underlying pile with `Repository::into_storage` and call
+`Pile::close()` yourself.
 
 See the [crate documentation](https://docs.rs/tribles/latest/tribles/) for
 additional modules and examples.


### PR DESCRIPTION
## Summary
- explain in the getting started guide that explicitly closing pile-backed repositories surfaces flush errors so readers can handle them
- update the changelog entry to mention the error-handling benefit of explicitly closing repos

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68ced60c6c348322a6936b8e968ce048