### PR TITLE
Document copy_reachable GC use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Serializable`.
 - Documented that branch updates do not ensure referenced blobs exist, enabling
   piles to serve as head-only stores.
+- Clarified repository workflow docs with a sidebar comparing `copy_reachable`
+  and `repo::transfer`, including garbage-collection scenarios that only copy
+  live blobs.
 - Clarified that multiple pile writers require filesystems with atomic append
   semantics; noted unsupported filesystems in documentation.
 - Documented the pile as a write-ahead log database ("WAL-as-a-DB").

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -154,6 +154,23 @@ Internally this uses `repo::copy_reachable` and `Workspace::merge_commit`.
 Because `copy_reachable` scans aligned 32‑byte chunks, it is forward‑compatible
 with new formats as long as embedded handles remain 32‑aligned.
 
+> **Sidebar — Choosing a copy routine**
+> - `repo::copy_reachable` walks the graph starting from the commits you
+>   provide. It follows 32-byte-aligned handles inside each blob and only
+>   uploads objects that are actually reachable from those heads. This keeps
+>   merge-import fast when both piles share the same hash protocol and you just
+>   need to graft a foreign history, and it doubles as a mark-and-sweep style
+>   collector when you want to copy only the live blobs into a fresh pile.
+> - `repo::transfer` iterates every blob that the source store exposes and
+>   returns an iterator of `(old_handle, new_handle)` pairs as it writes them
+>   into the destination. That exhaustive pass is ideal for full backups or for
+>   migrating into a store that uses a different hash protocol where you must
+>   rewrite every reference.
+>
+> Reachable copy keeps imports minimal; the transfer helper trades extra work
+> for a complete mapping when you need to rewrite handles or duplicate an
+> entire pile.
+
 ### Programmatic example (Rust)
 
 The same flow can be used directly from Rust when you have two piles on disk and


### PR DESCRIPTION
## Summary
- add a sidebar to the merge-import workflow explaining when to choose `copy_reachable` versus `repo::transfer`, including mark-and-sweep style garbage-collection use cases
- note the documentation update in the changelog

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68ced6383cdc8322a20805c98b0c0026