### PR TITLE
Document backlog notes for book improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Documented repository storage backends and added a book page tracking future
   documentation improvements.
+- Expanded the documentation backlog with notes on remote object-store conflict
+  handling, succinct archive indexes, and extending regular path engines.
 - Glossary chapter in the book for quick reference to core terminology.
 - Expanded the Identifiers chapter with a `local_ids` + `IdOwner` workflow
   example showing how to borrow freshly minted IDs in queries.

--- a/book/src/documentation-improvements.md
+++ b/book/src/documentation-improvements.md
@@ -8,7 +8,11 @@ prioritise the most useful additions.
   wires the repository into [`object_store`](https://docs.rs/object_store/latest/object_store/)
   services such as S3, local filesystems or Azure storage. A step-by-step guide
   should show how to configure credentials, pick a prefix and combine the remote
-  backend with other stores (for example via `HybridStore`).
+  backend with other stores (for example via `HybridStore`). The chapter should
+  also spell out how branch updates rely on `PutMode::Update`/`UpdateVersion`
+  retries, how conflicts are surfaced, and how blob and branch listings are
+  streamed through the `BlockingIter` adapter so users know what consistency
+  guarantees to expect.【F:src/repo/objectstore.rs†L108-L316】
 - **Hybrid storage recipes** &mdash; The `repo::hybridstore::HybridStore` adapter
   mixes a blob store with a separate branch store. Documenting common layouts
   (remote blobs + local branches, or piles + in-memory branches) would help
@@ -26,6 +30,19 @@ prioritise the most useful additions.
   the high-level approach, but it could reference concrete APIs such as
   `repo::reachable`, `repo::transfer`, and `MemoryBlobStore::keep` to show how to
   compute and retain the reachable set in code.
+- **Succinct archive indexes** &mdash; `blob::schemas::succinctarchive::SuccinctArchive`
+  converts a `TribleSet` into compressed wavelet matrices, exposes helpers such
+  as `distinct_in`/`enumerate_in`, implements `TriblePattern` and serialises via
+  ordered, compressed or cached `Universe` implementations. A dedicated section
+  should walk through building an archive from a set, choosing a universe,
+  storing it as a blob and querying it directly through
+  `SuccinctArchiveConstraint` so readers can reuse the on-disk index without
+  round-tripping through `TribleSet` conversions.【F:src/blob/schemas/succinctarchive.rs†L100-L529】【F:src/blob/schemas/succinctarchive/universe.rs†L16-L265】【F:src/blob/schemas/succinctarchive/succinctarchiveconstraint.rs†L9-L200】
+- **Extensible path engines** &mdash; Regular path queries run through
+  `RegularPathConstraint` which delegates edge checks to the `PathEngine` trait.
+  Document how the built-in `ThompsonEngine` constructs NFAs from a `TribleSet`
+  and show how to plug in alternative engines backed by other graph stores so
+  readers can extend the regex-based traversal beyond in-memory datasets.【F:src/query/regularpathconstraint.rs†L1-L200】
 
 Treat these bullets as a living backlog for book improvements. As the
 implementation evolves, refresh the list so the documentation keeps pace with


### PR DESCRIPTION
## Summary
- extend the documentation backlog with notes about remote object-store conflict handling, succinct archive indexes, and extensible path engines
- record the backlog additions in the changelog

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3dfd02fe8832280e436a9a0db2e74