### PR TITLE
Update Query Engine macro references in book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Repository::pull_with_key`.
 
 ### Changed
+- Query Engine chapter now directs readers to the crate-level `pattern!` and
+  `entity!` macros and shows how to import them via the prelude.
 - Clarified that `find!` retrieves `ExclusiveId` bindings via `FromValue` and
   that restricting queries with `local_ids` keeps the conversion safe.
 - Getting started guide now demonstrates defining custom attributes alongside

--- a/book/src/query-engine.md
+++ b/book/src/query-engine.md
@@ -44,11 +44,14 @@ still allowing the engine to explore the search space efficiently.
 The query engine and data model are flexible enough to support many query
 styles, including graph, relational and document-oriented queries.
 
-For example, the [`namespace`](crate::namespace) module offers macros that
-generate constraints for a given trible pattern in a query-by-example style
-reminiscent of SPARQL or GraphQL but tailored to a document-graph data model.
-It would also be possible to layer a property-graph language like Cypher or a
-relational language like Datalog on top of the engine.[^3]
+For example, the [`pattern!`](crate::pattern!) and
+[`entity!`](crate::entity!) macros—available at the crate root and re-exported
+via [`tribles::prelude`](crate::prelude) (for instance with
+`use tribles::prelude::*;`)—generate constraints for a given trible pattern in
+a query-by-example style reminiscent of SPARQL or GraphQL but tailored to a
+document-graph data model. It would also be possible to layer a property-graph
+language like Cypher or a relational language like Datalog on top of the
+engine.[^3]
 
 Great care has been taken to ensure that query languages with different styles
 and semantics can coexist and even be mixed with other languages and data models


### PR DESCRIPTION
## Summary
- point the Query Engine chapter at the crate-level `pattern!`/`entity!` macros and mention the prelude re-export
- record the documentation refresh in the changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d3fad7f81c8322b5ca027462c1dac6