### PR TITLE
Document TribleSet operations in book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remote store workflow example in the book showing how to open
   `ObjectStoreRemote` repositories and clarifying that no explicit close is
   required for remote backends.
+- Documented `TribleSet` set operations and monotonic semantics in the Trible
+  Structure chapter.
 - Test coverage for `branch_from` and `pull_with_key`.
 - Migrated `SuccinctArchive` to new `jerky`/`anybytes` APIs and added
   serializable metadata.

--- a/book/src/deep-dive/trible-structure.md
+++ b/book/src/deep-dive/trible-structure.md
@@ -76,6 +76,27 @@ resistant to skew.
   resistance, making it likely that a similar format would emerge through
   convergent evolution and could serve as a universal data interchange format.
 
+## Set operations and monotonic semantics
+
+`TribleSet`s provide familiar set-theoretic helpers such as
+[`TribleSet::union`](https://docs.rs/tribles/latest/tribles/trible/struct.TribleSet.html#method.union),
+[`TribleSet::intersection`](https://docs.rs/tribles/latest/tribles/trible/struct.TribleSet.html#method.intersection)
+and
+[`TribleSet::difference`](https://docs.rs/tribles/latest/tribles/trible/struct.TribleSet.html#method.difference).
+Each of these operations returns a new `TribleSet` view without modifying the
+inputs, making it straightforward to merge datasets, locate their overlap or
+identify the facts that still need to propagate between replicas while keeping
+all sources intact.
+
+This design reflects the crate's commitment to CALM-friendly, monotonic
+semantics. New information can be added freely, but existing facts are never
+destroyed. Consequently, `difference` is intended for comparing snapshots
+(e.g. "which facts are present in the remote set that I have not yet
+indexed?") rather than for destructive deletion. This keeps workflows
+declarative and convergent: sets can be combined in any order without
+introducing conflicts, and subtraction simply reports the gaps that remain to
+be filled.
+
 # Direction and Consistency
 
 In other triple stores the direction of the edge drawn by a triple is often


### PR DESCRIPTION
## Summary
- describe TribleSet union/intersection/difference helpers in the Trible Structure deep dive
- explain how the difference helper supports CALM-friendly monotonic workflows rather than deletions
- record the documentation update in the changelog

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3fb1670708322b46b1b91a96cff01