### PR TITLE
Use public macros in documentation samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Getting started guide now demonstrates defining custom attributes alongside
   the quick-start example, hides doc-test-only cleanup, and exercises the
   quick-start snippet as a runnable doc test.
+- Updated README and book code samples to use the public `entity!`/`pattern!`
+  macros so snippets copy-and-paste outside the crate.
 - Updated the README and book examples to use `Repository::create_branch` plus
   `pull` instead of the removed `branch` helper when initializing workspaces.
 - Updated `SuccinctArchive` to use `BitVectorDataMeta` for prefix bit vectors.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let branch_id = repo.create_branch("main", None)?;
     let mut ws = repo.pull(*branch_id)?;
 
-    ws.commit(crate::entity!{ &ufoid() @ literature::firstname: "Alice" }, None);
+    ws.commit(entity!{ &ufoid() @ literature::firstname: "Alice" }, None);
     repo.push(&mut ws)?;
     Ok(())
 }
@@ -97,12 +97,12 @@ fn main() -> std::io::Result<()> {
 
     // Note how the entity macro returns TribleSets that can be cheaply merged
     // into our existing dataset.
-    set += crate::entity!{ &author_id @
+    set += entity!{ &author_id @
                 literature::firstname: "Frank",
                 literature::lastname: "Herbert",
             };
 
-    set += crate::entity!{ &author_id @
+    set += entity!{ &author_id @
                 literature::title: "Dune",
                 literature::author: &author_id,
                 literature::quote: blobs.put("Deep in the human unconscious is a \
@@ -121,7 +121,7 @@ fn main() -> std::io::Result<()> {
     // We can then find all entities matching a certain pattern in our dataset.
     for (_, f, l, q) in find!(
         (author: (), first: String, last: Value<_>, quote),
-        crate::pattern!(&set, [
+        pattern!(&set, [
             { ?author @
                 literature::firstname: ?first,
                 literature::lastname: ?last

--- a/book/src/deep-dive/blobs.md
+++ b/book/src/deep-dive/blobs.md
@@ -28,7 +28,7 @@ let quote_b = memory_store
     .put("I must not fear. Fear is the mind-killer. Fear is the little-death that brings total obliteration. I will face my fear. I will permit it to pass over me and through me. And when it has gone past I will turn the inner eye to see its path. Where the fear has gone there will be nothing. Only I will remain.")
     .unwrap();
 
-let set = crate::entity!{
+let set = entity!{
    literature::title: "Dune",
    literature::author: &book_author_id,
    literature::quote: quote_a,
@@ -50,7 +50,7 @@ let signature: Signature = commit_author_key.sign(
 );
 
 // Store the handle in another TribleSet.
-let _meta_set = crate::entity!{
+let _meta_set = entity!{
    repo::content: archived_set_handle,
    repo::short_message: "Initial commit",
    repo::signed_by: commit_author_key.verifying_key(),

--- a/book/src/query-language.md
+++ b/book/src/query-language.md
@@ -195,8 +195,8 @@ mod social {
 }
 let mut kb = TribleSet::new();
 let a = fucid(); let b = fucid(); let c = fucid();
-kb += crate::entity!{ &a @ social::follows: &b };
-kb += crate::entity!{ &b @ social::likes: &c };
+kb += entity!{ &a @ social::follows: &b };
+kb += entity!{ &b @ social::likes: &c };
 
 let results: Vec<_> = find!((s: Value<_>, e: Value<_>),
     path!(&kb, s (social::follows | social::likes)+ e)).collect();


### PR DESCRIPTION
## Summary
- switch README snippets to call the exported `entity!` and `pattern!` macros
- update book examples to rely on the public macro paths after the prelude import
- record the documentation tweak in the changelog

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3fb5e7fe88322b6b52d31979e6230