### PR TITLE
Document repository failure modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented zero-length blob support and added tests for empty blob insertion and retrieval.
 - `with_sorted_dedup` constructor for universes to build from already sorted,
   deduplicated value sequences.
+- Troubleshooting table in the repository workflows chapter covering common
+  push, branch, and pull failure modes.
 - Book section documenting how to manage multiple signing identities with
   `Repository::set_signing_key`, `Repository::create_branch_with_key`, and
   `Repository::pull_with_key`.


### PR DESCRIPTION
## Summary
- document push, branch, and pull failure modes in the repository workflows chapter
- note the new troubleshooting guidance in the changelog

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3fbbdacd88322bd34e9caa686447e