### PR TITLE
Streamline merge troubleshooting note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   garbage-collection scenarios that only copy live blobs.
 - Clarified that multiple pile writers require filesystems with atomic append
   semantics; noted unsupported filesystems in documentation.
+- Streamlined the merge troubleshooting note to highlight
+  `MergeError::DifferentRepos` and the `reachable` + `repo::transfer` steps for
+  cross-repository merges.
 - Documented the pile as a write-ahead log database ("WAL-as-a-DB").
 - Rewrote the pile blob metadata chapter to describe the `BlobMetadata`
   API and linked it from the pile format documentation.

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -233,6 +233,13 @@ while let Some(mut incoming) = repo.push(&mut ws)? {
 }
 ```
 
+> **Troubleshooting:** `Workspace::merge` succeeds only when both workspaces
+> share a blob store. Merging a workspace pulled from a different pile or
+> remote returns `MergeError::DifferentRepos`. Decide which repository will own
+> the combined history, transfer the other branch's reachable blobs into it with
+> `repo::transfer(reachable(...))`, create a branch for that imported head, and
+> merge locally once both workspaces target the same store.
+
 After a successful push the branch may have advanced further than the head
 supplied, because the repository refreshes its view after releasing the lock.
 An error indicating a corrupted pile does not necessarily mean the push failed;


### PR DESCRIPTION
## Summary
- streamline the repository workflows troubleshooting note so the merge preconditions and cross-repo transfer steps read more crisply
- refresh the changelog entry to reference the tighter guidance

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3fb423be48322aa6805470fd956e8