### PR TITLE
Clarify commit range semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Repository::pull_with_key`.
 
 ### Changed
+- Reframed commit range selectors so `start..end` walks from the end selector
+  until encountering a commit yielded by the start selector, reducing
+  redundant ancestor exploration and making the traversal cost explicit.
 - Query Engine chapter now directs readers to the crate-level `pattern!` and
   `entity!` macros and shows how to import them via the prelude.
 - Removed the outdated note that parentheses "force" literals in the getting
@@ -507,8 +510,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced an `ancestors` selector to retrieve a commit and its history.
 - Commit selectors now return a `CommitSet` patch of commit handles instead of a `Vec`.
 - Renamed the `CommitPatch` type alias to `CommitSet`.
-- The `..` commit selector now computes `reachable(end) minus reachable(start)`
-  via set operations, matching Git's two-dot semantics even across merges.
+- The `..` commit selector now walks from the end boundary until it encounters
+  a commit returned by the start selector. To reproduce Git's set-difference
+  semantics, wrap the boundary explicitly as `ancestors(start)..end`.
 - Added a `symmetric_diff` selector corresponding to Git's `A...B` three-dot
   syntax.
 - Refined candidate built-in schemas in `INVENTORY.md`; removed `Bool`, the


### PR DESCRIPTION
## Summary
- clarify that the two-dot range selectors stop walking when they encounter commits from the start boundary instead of subtracting ancestor closures
- update the book and changelog to document the new semantics and explain how to recover Git-style behaviour with `ancestors(...)`
- add a regression test covering sibling commits so ancestors reachable through alternate paths remain visible

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68dc0e61107083228677e1540d9283cf