### PR TITLE
Clarify tribles-macros crate overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Repository::pull_with_key`.
 
 ### Changed
+- Documented the `path!`, `attributes!`, and `pattern_changes!` procedural
+  macros in the `tribles-macros` crate overview.
 - Query Engine chapter now directs readers to the crate-level `pattern!` and
   `entity!` macros and shows how to import them via the prelude.
 - Removed the outdated note that parentheses "force" literals in the getting

--- a/tribles-macros/src/lib.rs
+++ b/tribles-macros/src/lib.rs
@@ -1,13 +1,22 @@
 //! Procedural macro implementations used by the `tribles` crate.
 //!
-//! The macros here mirror the declarative macros defined in
-//! [`src/namespace.rs`](https://github.com/tribles/tribles-rust/blob/main/src/namespace.rs)
-//! but are implemented with `proc_macro` to allow more complex analysis and
-//! additional features in the future.  The crate currently exposes two macros:
-//! [`pattern!`], which expands namespace patterns into an
-//! [`IntersectionConstraint`] of query constraints, and [`entity!`], which
-//! constructs [`TribleSet`]s from namespace attribute assignments or inserts
-//! triples into an existing set.
+//! The macros here power the public helpers re-exported by the `tribles` crate
+//! (for example `tribles::pattern!` and `tribles::entity!`). They originated as
+//! declarative macros in the main crate but now live here as procedural macros
+//! so we can perform richer analysis, emit better diagnostics, and extend the
+//! syntax without running into `macro_rules!` limitations. The crate currently
+//! exposes five macros:
+//!
+//! * `path!` produces `RegularPathConstraint` values from a compact
+//!   regular-expression-like syntax so queries can follow attribute paths.
+//! * `attributes!` generates strongly typed attribute constants from the
+//!   canonical hex identifiers used in schemas.
+//! * `pattern!` expands namespace patterns into an `IntersectionConstraint` of
+//!   query constraints.
+//! * `entity!` constructs `TribleSet`s from namespace attribute assignments or
+//!   inserts triples into an existing set.
+//! * `pattern_changes!` mirrors `pattern!` but produces a `UnionConstraint`
+//!   across a base dataset and a set of staged insertions.
 //!
 //! ```ignore
 //! // Match an entity whose `my_ns::attr` equals the literal 42


### PR DESCRIPTION
## Summary
- expand the tribles-macros crate-level documentation to mention every procedural macro and describe how each supports the public API
- record the documentation update in the changelog

## Testing
- cargo fmt
- cargo doc --no-deps -p tribles-macros
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dc740d2b8c83228376d265ceca509f