### PR TITLE
Clarify ordered iterator docs with prefix guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Repository::pull_with_key`.
 
 ### Changed
+- Clarified `PATCH::iter_ordered` and `PATCHOrderedIterator` documentation to
+  describe the full tree-order traversal without a prefix filter and point to
+  the prefix iterator for filtered traversal.
 - Query Engine chapter now directs readers to the crate-level `pattern!` and
   `entity!` macros and shows how to import them via the prelude.
 - Removed the outdated note that parentheses "force" literals in the getting

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1162,8 +1162,11 @@ where
         PATCHIterator::new(self)
     }
 
-    /// Iterates over all keys in the PATCH.
-    /// The keys are returned in key ordering and tree order.
+    /// Iterates over all keys in the PATCH in tree order.
+    ///
+    /// The traversal visits every key according to the tree's ordering, without
+    /// accepting a prefix filter. For prefix-aware iteration, see
+    /// [`PATCH::iter_prefix_count`].
     pub fn iter_ordered<'a>(&'a self) -> PATCHOrderedIterator<'a, KEY_LEN, O, V> {
         PATCHOrderedIterator::new(self)
     }
@@ -1348,8 +1351,11 @@ impl<'a, const KEY_LEN: usize, O: KeySchema<KEY_LEN>, V> std::iter::FusedIterato
 {
 }
 
-/// An iterator over all keys in a PATCH that have a given prefix.
-/// The keys are returned in tree ordering and in tree order.
+/// An iterator over every key in a PATCH, returned in tree order.
+///
+/// This iterator walks the full tree and does not accept a prefix filter. For
+/// prefix-aware iteration, use [`PATCHPrefixIterator`], constructed via
+/// [`PATCH::iter_prefix_count`].
 pub struct PATCHOrderedIterator<'a, const KEY_LEN: usize, O: KeySchema<KEY_LEN>, V> {
     stack: Vec<ArrayVec<&'a Head<KEY_LEN, O, V>, 256>>,
     remaining: usize,


### PR DESCRIPTION
## Summary
- mention that `PATCH::iter_ordered` traverses the full tree and suggest `iter_prefix_count` for prefix filters
- update `PATCHOrderedIterator` docs to reference the prefix iterator helper
- note the clarification in the changelog entry

## Testing
- cargo fmt
- cargo test
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68dc740dcc388322a1549bd10873d0fe